### PR TITLE
Dev

### DIFF
--- a/sw/inc/Delegate.h
+++ b/sw/inc/Delegate.h
@@ -632,7 +632,7 @@ namespace sw
         /**
          * @brief 移动构造函数
          */
-        Delegate(Delegate &&other)
+        Delegate(Delegate &&other) noexcept
             : _data(std::move(other._data))
         {
         }
@@ -655,7 +655,7 @@ namespace sw
         /**
          * @brief 移动赋值运算符
          */
-        Delegate &operator=(Delegate &&other)
+        Delegate &operator=(Delegate &&other) noexcept
         {
             if (this != &other) {
                 _data = std::move(other._data);
@@ -834,7 +834,7 @@ namespace sw
          * @brief  判断当前委托是否等于nullptr
          * @return 如果委托为空则返回true，否则返回false
          */
-        bool operator==(std::nullptr_t) const
+        bool operator==(std::nullptr_t) const noexcept
         {
             return _data.IsEmpty();
         }
@@ -843,7 +843,7 @@ namespace sw
          * @brief  判断当前委托是否不等于nullptr
          * @return 如果委托不为空则返回true，否则返回false
          */
-        bool operator!=(std::nullptr_t) const
+        bool operator!=(std::nullptr_t) const noexcept
         {
             return !_data.IsEmpty();
         }
@@ -852,7 +852,7 @@ namespace sw
          * @brief  判断当前委托是否有效
          * @return 如果委托不为空则返回true，否则返回false
          */
-        operator bool() const
+        operator bool() const noexcept
         {
             return !_data.IsEmpty();
         }
@@ -1048,7 +1048,7 @@ namespace sw
      * @note  如果委托为空则返回true，否则返回false
      */
     template <typename TRet, typename... Args>
-    inline bool operator==(std::nullptr_t, const Delegate<TRet(Args...)> &d)
+    inline bool operator==(std::nullptr_t, const Delegate<TRet(Args...)> &d) noexcept
     {
         return d == nullptr;
     }
@@ -1058,7 +1058,7 @@ namespace sw
      * @note  如果委托不为空则返回true，否则返回false
      */
     template <typename TRet, typename... Args>
-    inline bool operator!=(std::nullptr_t, const Delegate<TRet(Args...)> &d)
+    inline bool operator!=(std::nullptr_t, const Delegate<TRet(Args...)> &d) noexcept
     {
         return d != nullptr;
     }


### PR DESCRIPTION
This pull request refactors the `Delegate` class and related internal classes to improve exception safety, clarify intent, and enhance code robustness. The main changes include marking move operations and comparison operators as `noexcept`, refactoring invocation logic for better error handling, and marking certain internal classes as `final` to prevent further inheritance.

**Exception safety and operator improvements:**

* Marked move constructor, move assignment operator, and all comparison operators (`operator==`, `operator!=`, and `operator bool`) in `Delegate` as `noexcept` to clearly indicate they do not throw exceptions. [[1]](diffhunk://#diff-a4bda853a504f9ed863fb661805568da8c80439db49de0aabcefff25d722783fL635-R635) [[2]](diffhunk://#diff-a4bda853a504f9ed863fb661805568da8c80439db49de0aabcefff25d722783fL658-R658) [[3]](diffhunk://#diff-a4bda853a504f9ed863fb661805568da8c80439db49de0aabcefff25d722783fL837-R837) [[4]](diffhunk://#diff-a4bda853a504f9ed863fb661805568da8c80439db49de0aabcefff25d722783fL846-R846) [[5]](diffhunk://#diff-a4bda853a504f9ed863fb661805568da8c80439db49de0aabcefff25d722783fL855-R855) [[6]](diffhunk://#diff-a4bda853a504f9ed863fb661805568da8c80439db49de0aabcefff25d722783fL1028-R1051) [[7]](diffhunk://#diff-a4bda853a504f9ed863fb661805568da8c80439db49de0aabcefff25d722783fL1038-R1061)

**Internal class design:**

* Marked `_CallableWrapperImpl`, `_MemberFuncWrapper`, and `_ConstMemberFuncWrapper` as `final` to prevent further inheritance and clarify their intended usage. [[1]](diffhunk://#diff-a4bda853a504f9ed863fb661805568da8c80439db49de0aabcefff25d722783fL416-R416) [[2]](diffhunk://#diff-a4bda853a504f9ed863fb661805568da8c80439db49de0aabcefff25d722783fL494-R494) [[3]](diffhunk://#diff-a4bda853a504f9ed863fb661805568da8c80439db49de0aabcefff25d722783fL530-R530)

**Invocation logic and error handling:**

* Refactored the invocation logic by introducing a private `_InvokeImpl` method, which both `operator()` and `Invoke` now use, ensuring consistent error handling and code reuse. [[1]](diffhunk://#diff-a4bda853a504f9ed863fb661805568da8c80439db49de0aabcefff25d722783fL810-R810) [[2]](diffhunk://#diff-a4bda853a504f9ed863fb661805568da8c80439db49de0aabcefff25d722783fL932-R932) [[3]](diffhunk://#diff-a4bda853a504f9ed863fb661805568da8c80439db49de0aabcefff25d722783fR1016-R1041)
* Added a private `_ThrowEmptyDelegateError` method to centralize and clarify exception throwing when invoking an empty delegate.

**Behavioral changes for multi-cast delegates:**

* Improved `InvokeAll` to throw an exception if the delegate is empty, matching the behavior of other invocation methods, and clarified result collection for multiple delegates.