### PR TITLE
修正vs2015编译失败

### DIFF
--- a/sw/src/Window.cpp
+++ b/sw/src/Window.cpp
@@ -25,7 +25,8 @@ namespace
 const sw::ReadOnlyProperty<sw::Window *> sw::Window::ActiveWindow(
     []() -> sw::Window * {
         HWND hwnd = GetActiveWindow();
-        return _GetWindowPtr(hwnd);
+        // return _GetWindowPtr(hwnd); // vs2015无法识别此处的作用域？
+        return reinterpret_cast<sw::Window *>(GetPropW(hwnd, _WindowPtrProp));
     } //
 );
 


### PR DESCRIPTION
Replaces the call to _GetWindowPtr with a reinterpret_cast using GetPropW to retrieve the window pointer. This change addresses a scope recognition issue in Visual Studio 2015.