### PR TITLE
给部分成员函数添加const标记

### DIFF
--- a/sw/inc/WndBase.h
+++ b/sw/inc/WndBase.h
@@ -746,12 +746,12 @@ namespace sw
         /**
          * @brief 判断当前对象在界面中是否可视，与Visible属性不同的是该函数返回值会受父窗口的影响
          */
-        bool IsVisible();
+        bool IsVisible() const;
 
         /**
          * @brief 获取窗口样式
          */
-        DWORD GetStyle();
+        DWORD GetStyle() const;
 
         /**
          * @brief 设置窗口样式
@@ -762,7 +762,7 @@ namespace sw
          * @brief      判断窗口是否设有指定样式
          * @param mask 样式的位掩码，可以是多个样式
          */
-        bool GetStyle(DWORD mask);
+        bool GetStyle(DWORD mask) const;
 
         /**
          * @brief       打开或关闭指定的样式
@@ -774,7 +774,7 @@ namespace sw
         /**
          * @brief 获取扩展窗口样式
          */
-        DWORD GetExtendedStyle();
+        DWORD GetExtendedStyle() const;
 
         /**
          * @brief 设置扩展窗口样式
@@ -799,14 +799,14 @@ namespace sw
          * @param point 用户区坐标
          * @return      该点在屏幕上的坐标
          */
-        Point PointToScreen(const Point &point);
+        Point PointToScreen(const Point &point) const;
 
         /**
          * @brief             获取屏幕上点在当前用户区点的位置
          * @param screenPoint 屏幕上点的坐标
          * @return            该点在用户区的坐标
          */
-        Point PointFromScreen(const Point &screenPoint);
+        Point PointFromScreen(const Point &screenPoint) const;
 
         /**
          * @brief 发送消息（ASCII）

--- a/sw/src/WndBase.cpp
+++ b/sw/src/WndBase.cpp
@@ -1073,12 +1073,12 @@ void sw::WndBase::Redraw(bool erase, bool updateWindow)
     if (updateWindow) UpdateWindow(this->_hwnd);
 }
 
-bool sw::WndBase::IsVisible()
+bool sw::WndBase::IsVisible() const
 {
     return IsWindowVisible(this->_hwnd);
 }
 
-DWORD sw::WndBase::GetStyle()
+DWORD sw::WndBase::GetStyle() const
 {
     return DWORD(GetWindowLongPtrW(this->_hwnd, GWL_STYLE));
 }
@@ -1088,7 +1088,7 @@ void sw::WndBase::SetStyle(DWORD style)
     SetWindowLongPtrW(this->_hwnd, GWL_STYLE, LONG_PTR(style));
 }
 
-bool sw::WndBase::GetStyle(DWORD mask)
+bool sw::WndBase::GetStyle(DWORD mask) const
 {
     return (DWORD(GetWindowLongPtrW(this->_hwnd, GWL_STYLE)) & mask) == mask;
 }
@@ -1101,7 +1101,7 @@ void sw::WndBase::SetStyle(DWORD mask, bool value)
     SetWindowLongPtrW(this->_hwnd, GWL_STYLE, LONG_PTR(newstyle));
 }
 
-DWORD sw::WndBase::GetExtendedStyle()
+DWORD sw::WndBase::GetExtendedStyle() const
 {
     return DWORD(GetWindowLongPtrW(this->_hwnd, GWL_EXSTYLE));
 }
@@ -1124,14 +1124,14 @@ void sw::WndBase::SetExtendedStyle(DWORD mask, bool value)
     SetWindowLongPtrW(this->_hwnd, GWL_EXSTYLE, LONG_PTR(newstyle));
 }
 
-sw::Point sw::WndBase::PointToScreen(const Point &point)
+sw::Point sw::WndBase::PointToScreen(const Point &point) const
 {
     POINT p = point;
     ClientToScreen(this->_hwnd, &p);
     return p;
 }
 
-sw::Point sw::WndBase::PointFromScreen(const Point &screenPoint)
+sw::Point sw::WndBase::PointFromScreen(const Point &screenPoint) const
 {
     POINT p = screenPoint;
     ScreenToClient(this->_hwnd, &p);


### PR DESCRIPTION
Added 'const' qualifier to several accessor methods in WndBase, including IsVisible, GetStyle, GetExtendedStyle, PointToScreen, and PointFromScreen. This improves const-correctness and allows these methods to be called on const instances.