### PR TITLE
Hotfix/resethandle

### DIFF
--- a/sw/inc/Control.h
+++ b/sw/inc/Control.h
@@ -54,6 +54,8 @@ namespace sw
         /**
          * @brief         销毁控件句柄并重新初始化，该操作会创建新的句柄并设置样式、文本、字体等
          * @param lpParam 创建控件句柄时传给CreateWindowExW的参数
+         * @return        若函数成功则返回true，否则返回false
+         * @note          该函数只能在创建控件的线程调用
          */
         bool ResetHandle(LPVOID lpParam = NULL);
 
@@ -62,6 +64,8 @@ namespace sw
          * @param style   新的样式
          * @param exStyle 新的扩展样式
          * @param lpParam 创建控件句柄时传给CreateWindowExW的参数
+         * @return        若函数成功则返回true，否则返回false
+         * @note          该函数只能在创建控件的线程调用
          */
         bool ResetHandle(DWORD style, DWORD exStyle, LPVOID lpParam = NULL);
 

--- a/sw/src/Control.cpp
+++ b/sw/src/Control.cpp
@@ -37,7 +37,11 @@ bool sw::Control::ResetHandle(LPVOID lpParam)
 
 bool sw::Control::ResetHandle(DWORD style, DWORD exStyle, LPVOID lpParam)
 {
-    RECT rect = Rect.Get();
+    if (!CheckAccess()) {
+        return false;
+    }
+
+    RECT rect = Rect;
     auto text = GetInternalText().c_str();
 
     HWND oldHwnd = _hwnd;


### PR DESCRIPTION
This pull request refactors the `sw::Control` class to improve code consistency, return value clarity, and thread safety documentation. The most significant changes include updating the `ResetHandle` methods to return a boolean indicating success, adding thread safety notes, and removing redundant `this->` usage for better readability.

### API improvements and documentation

* Changed the return type of `ResetHandle` methods in `Control.h` and `Control.cpp` from `void` to `bool`, so callers can check if the operation succeeded. Updated documentation to reflect the new return value and added notes about thread safety. [[1]](diffhunk://#diff-53f9aa852541e60e50ddc3f06e4788e7b10188a80c678a71863be9ef2b3e99e9R57-R70) [[2]](diffhunk://#diff-3d8d71021a9ffd16cda244506075358ad431ec38cc5a99ce15233de7a6cb8d02L31-R47)
* Added a check to ensure `ResetHandle` is only called from the creating thread, returning `false` if called from another thread.

### Code consistency and readability

* Removed unnecessary `this->` qualifiers throughout `Control.cpp`, simplifying member access and improving code readability. [[1]](diffhunk://#diff-3d8d71021a9ffd16cda244506075358ad431ec38cc5a99ce15233de7a6cb8d02L7-R17) [[2]](diffhunk://#diff-3d8d71021a9ffd16cda244506075358ad431ec38cc5a99ce15233de7a6cb8d02L73-R134) [[3]](diffhunk://#diff-3d8d71021a9ffd16cda244506075358ad431ec38cc5a99ce15233de7a6cb8d02L156-R171)
* Standardized member variable usage by removing redundant `this->` and using direct member variable access (e.g., `_hwnd`, `_drawFocusRect`). [[1]](diffhunk://#diff-3d8d71021a9ffd16cda244506075358ad431ec38cc5a99ce15233de7a6cb8d02L7-R17) [[2]](diffhunk://#diff-3d8d71021a9ffd16cda244506075358ad431ec38cc5a99ce15233de7a6cb8d02L73-R134) [[3]](diffhunk://#diff-3d8d71021a9ffd16cda244506075358ad431ec38cc5a99ce15233de7a6cb8d02L156-R171)

### Minor logic adjustments

* Ensured that `ResetHandle` returns a boolean status after completing its operations, and that all relevant code paths return a value.