### PR TITLE
Refactor/addconst interfaces

### DIFF
--- a/sw/inc/ILayout.h
+++ b/sw/inc/ILayout.h
@@ -21,12 +21,12 @@ namespace sw
         /**
          * @brief 获取布局标记
          */
-        virtual uint64_t GetLayoutTag() = 0;
+        virtual uint64_t GetLayoutTag() const = 0;
 
         /**
          * @brief 获取子控件的数量
          */
-        virtual int GetChildLayoutCount() = 0;
+        virtual int GetChildLayoutCount() const = 0;
 
         /**
          * @brief 获取对应索引处的子控件
@@ -36,7 +36,7 @@ namespace sw
         /**
          * @brief 获取控件所需尺寸
          */
-        virtual Size GetDesireSize() = 0;
+        virtual Size GetDesireSize() const = 0;
 
         /**
          * @brief               测量控件所需尺寸

--- a/sw/inc/ITag.h
+++ b/sw/inc/ITag.h
@@ -19,7 +19,7 @@ namespace sw
         /**
          * @brief 获取Tag
          */
-        virtual uint64_t GetTag() = 0;
+        virtual uint64_t GetTag() const = 0;
 
         /**
          * @brief 设置Tag

--- a/sw/inc/MenuItem.h
+++ b/sw/inc/MenuItem.h
@@ -115,7 +115,7 @@ namespace sw
         /**
          * @brief 获取Tag
          */
-        virtual uint64_t GetTag() override;
+        virtual uint64_t GetTag() const override;
 
         /**
          * @brief 设置Tag

--- a/sw/inc/UIElement.h
+++ b/sw/inc/UIElement.h
@@ -813,13 +813,13 @@ namespace sw
         /**
          * @brief 获取布局标记
          */
-        virtual uint64_t GetLayoutTag() override;
+        virtual uint64_t GetLayoutTag() const override;
 
         /**
          * @brief 获取参与布局的子元素数量
          * @note  参与布局的子元素：即非collapsed状态的元素
          */
-        virtual int GetChildLayoutCount() override;
+        virtual int GetChildLayoutCount() const override;
 
         /**
          * @brief 获取对应索引处的子元素，只索引参与布局的子元素
@@ -830,7 +830,7 @@ namespace sw
         /**
          * @brief 获取当前元素所需尺寸
          */
-        virtual Size GetDesireSize() override;
+        virtual Size GetDesireSize() const override;
 
         /**
          * @brief               测量元素所需尺寸

--- a/sw/inc/UIElement.h
+++ b/sw/inc/UIElement.h
@@ -803,7 +803,7 @@ namespace sw
         /**
          * @brief 获取Tag
          */
-        virtual uint64_t GetTag() override;
+        virtual uint64_t GetTag() const override;
 
         /**
          * @brief 设置Tag

--- a/sw/src/MenuItem.cpp
+++ b/sw/src/MenuItem.cpp
@@ -40,7 +40,7 @@ void sw::MenuItem::CallCommand()
         this->command(*this);
 }
 
-uint64_t sw::MenuItem::GetTag()
+uint64_t sw::MenuItem::GetTag() const
 {
     return this->tag;
 }

--- a/sw/src/UIElement.cpp
+++ b/sw/src/UIElement.cpp
@@ -631,7 +631,7 @@ bool sw::UIElement::BringIntoView()
     return false;
 }
 
-uint64_t sw::UIElement::GetTag()
+uint64_t sw::UIElement::GetTag() const
 {
     return this->_tag;
 }

--- a/sw/src/UIElement.cpp
+++ b/sw/src/UIElement.cpp
@@ -641,12 +641,12 @@ void sw::UIElement::SetTag(uint64_t tag)
     this->_tag = tag;
 }
 
-uint64_t sw::UIElement::GetLayoutTag()
+uint64_t sw::UIElement::GetLayoutTag() const
 {
     return this->_layoutTag;
 }
 
-int sw::UIElement::GetChildLayoutCount()
+int sw::UIElement::GetChildLayoutCount() const
 {
     return (int)this->_layoutVisibleChildren.size();
 }
@@ -656,7 +656,7 @@ sw::ILayout &sw::UIElement::GetChildLayoutAt(int index)
     return *this->_layoutVisibleChildren[index];
 }
 
-sw::Size sw::UIElement::GetDesireSize()
+sw::Size sw::UIElement::GetDesireSize() const
 {
     return this->_desireSize;
 }


### PR DESCRIPTION
This pull request updates several interface and class method signatures in the `sw` namespace to mark them as `const`, ensuring these methods do not modify the object state and can be called on `const` instances. This change improves code safety and clarity, especially for getter methods.

Const-correctness improvements:

* Marked getter methods such as `GetTag`, `GetLayoutTag`, `GetChildLayoutCount`, and `GetDesireSize` as `const` in the `ILayout`, `ITag`, `MenuItem`, and `UIElement` interfaces and their implementations. [[1]](diffhunk://#diff-943f11169b48bd5d88f5a5e6d66713b77e68dfebbdeb09499a8d615cedf58a25L24-R29) [[2]](diffhunk://#diff-943f11169b48bd5d88f5a5e6d66713b77e68dfebbdeb09499a8d615cedf58a25L39-R39) [[3]](diffhunk://#diff-756c0ff251755bc06b7537cdf82c5bcb0a53c9ae2d80d38c802f888a687a68d1L22-R22) [[4]](diffhunk://#diff-ced4ed2b3f4ec82b1a330e4607d86df1fe6871ef1ee05a82110ebec47ca26ee5L118-R118) [[5]](diffhunk://#diff-5b541f27b269918273764c315481cf0b371d73bdc8e058679946f23c656a9378L806-R806) [[6]](diffhunk://#diff-5b541f27b269918273764c315481cf0b371d73bdc8e058679946f23c656a9378L816-R822) [[7]](diffhunk://#diff-5b541f27b269918273764c315481cf0b371d73bdc8e058679946f23c656a9378L833-R833) [[8]](diffhunk://#diff-e53beae389ea36c960e75799b2a3f099ddd5a5e1ef3dc61a5860424ab1a1c03cL43-R43) [[9]](diffhunk://#diff-13db186e9dedb13d4d2bffd3e1385bb5f85f49e4a7efecb7010fe3a2824657c8L634-R634) [[10]](diffhunk://#diff-13db186e9dedb13d4d2bffd3e1385bb5f85f49e4a7efecb7010fe3a2824657c8L644-R649) [[11]](diffhunk://#diff-13db186e9dedb13d4d2bffd3e1385bb5f85f49e4a7efecb7010fe3a2824657c8L659-R659)

These changes help enforce immutability for getter methods and improve compatibility with `const` objects throughout the codebase.