### PR TITLE
添加`RestoreRect`属性

### DIFF
--- a/sw/inc/Window.h
+++ b/sw/inc/Window.h
@@ -168,6 +168,11 @@ namespace sw
          */
         const Property<int> DialogResult;
 
+        /**
+         * @brief 窗口在最小化或最大化之前的位置和尺寸
+         */
+        const ReadOnlyProperty<sw::Rect> RestoreRect;
+
     public:
         /**
          * @brief 初始化窗口

--- a/sw/src/Window.cpp
+++ b/sw/src/Window.cpp
@@ -202,6 +202,15 @@ sw::Window::Window()
           [this](const int &value) {
               _dialogResult = value;
               Close();
+          }),
+
+      RestoreRect(
+          // get
+          [this]() -> sw::Rect {
+              WINDOWPLACEMENT wp{};
+              wp.length = sizeof(WINDOWPLACEMENT);
+              GetWindowPlacement(Handle, &wp);
+              return wp.rcNormalPosition;
           })
 {
     InitWindow(L"Window", WS_OVERLAPPEDWINDOW, 0);


### PR DESCRIPTION
Introduces a read-only RestoreRect property to the Window class, providing access to the window's position and size before minimization or maximization. This can be useful for restoring the window to its previous state.