### PR TITLE
Refactor/simplify traits

### DIFF
--- a/sw/inc/Delegate.h
+++ b/sw/inc/Delegate.h
@@ -398,8 +398,7 @@ namespace sw
 
         template <typename T>
         struct _IsEqualityComparable<
-            T,
-            typename std::enable_if<true, decltype(void(std::declval<T>() == std::declval<T>()))>::type> : std::true_type {
+            T, decltype(void(std::declval<T>() == std::declval<T>()))> : std::true_type {
         };
 
         template <typename T, typename = void>

--- a/sw/inc/Property.h
+++ b/sw/inc/Property.h
@@ -3,25 +3,22 @@
 #include "Delegate.h"
 #include <type_traits>
 
-#define _SW_DEFINE_OPERATION_HELPER(NAME, OP)                                                                                   \
-    template <typename T, typename U, typename = void>                                                                          \
-    struct NAME : std::false_type {                                                                                             \
-    };                                                                                                                          \
-    template <typename T, typename U>                                                                                           \
-    struct NAME<T,                                                                                                              \
-                U,                                                                                                              \
-                typename std::enable_if<true, decltype(void(std::declval<T>() OP std::declval<U>()))>::type> : std::true_type { \
-        using type = decltype(std::declval<T>() OP std::declval<U>());                                                          \
+#define _SW_DEFINE_OPERATION_HELPER(NAME, OP)                                                    \
+    template <typename T, typename U, typename = void>                                           \
+    struct NAME : std::false_type {                                                              \
+    };                                                                                           \
+    template <typename T, typename U>                                                            \
+    struct NAME<T, U, decltype(void(std::declval<T>() OP std::declval<U>()))> : std::true_type { \
+        using type = decltype(std::declval<T>() OP std::declval<U>());                           \
     }
 
-#define _SW_DEFINE_UNARY_OPERATION_HELPER(NAME, OP)                                                           \
-    template <typename T, typename = void>                                                                    \
-    struct NAME : std::false_type {                                                                           \
-    };                                                                                                        \
-    template <typename T>                                                                                     \
-    struct NAME<T,                                                                                            \
-                typename std::enable_if<true, decltype(void(OP std::declval<T>()))>::type> : std::true_type { \
-        using type = decltype(OP std::declval<T>());                                                          \
+#define _SW_DEFINE_UNARY_OPERATION_HELPER(NAME, OP)                         \
+    template <typename T, typename = void>                                  \
+    struct NAME : std::false_type {                                         \
+    };                                                                      \
+    template <typename T>                                                   \
+    struct NAME<T, decltype(void(OP std::declval<T>()))> : std::true_type { \
+        using type = decltype(OP std::declval<T>());                        \
     }
 
 namespace sw
@@ -113,8 +110,7 @@ namespace sw
      */
     template <typename T, typename U>
     struct _BracketOperationHelper<
-        T, U,
-        typename std::enable_if<true, decltype(void(std::declval<T>()[std::declval<U>()]))>::type> : std::true_type {
+        T, U, decltype(void(std::declval<T>()[std::declval<U>()]))> : std::true_type {
         using type = decltype(std::declval<T>()[std::declval<U>()]);
     };
 
@@ -130,8 +126,7 @@ namespace sw
      */
     template <typename TFrom, typename TTo>
     struct _IsExplicitlyConvertable<
-        TFrom, TTo,
-        typename std::enable_if<true, decltype(void(static_cast<TTo>(std::declval<TFrom>())))>::type> : std::true_type {
+        TFrom, TTo, decltype(void(static_cast<TTo>(std::declval<TFrom>())))> : std::true_type {
     };
 
     /**
@@ -164,7 +159,7 @@ namespace sw
      */
     template <typename T>
     struct _HasArrowOperator<
-        // T, typename std::enable_if<true, decltype(void(std::declval<T>().operator->()))>::type> : std::true_type {
+        // T, decltype(void(std::declval<T>().operator->()))> : std::true_type {
         T, typename std::enable_if<_HasArrowOperatorVs2015Fix<T>::value>::type> : std::true_type {
         using type = decltype(std::declval<T>().operator->());
     };

--- a/sw/inc/Utils.h
+++ b/sw/inc/Utils.h
@@ -9,28 +9,28 @@
 namespace sw
 {
     /**
-     * @brief 判断一个类型是否有ToString方法
-     */
-    template <typename T>
-    struct _HasToString {
-    private:
-        template <typename U>
-        static auto test(int) -> decltype(std::declval<U>().ToString(), std::true_type());
-
-        template <typename U>
-        static auto test(...) -> std::false_type;
-
-    public:
-        static constexpr bool value = decltype(test<T>(0))::value;
-    };
-
-    /**
      * @brief 工具类
      */
     class Utils
     {
     private:
         Utils() = delete; // 删除构造函数
+
+        /**
+         * @brief 判断一个类型是否有ToString方法
+         */
+        template <typename T, typename = void>
+        struct _HasToString : std::false_type {
+        };
+
+        /**
+         * @brief _HasToString偏特化版本
+         */
+        template <typename T>
+        struct _HasToString<
+            T,
+            decltype(void(std::declval<T>().ToString()))> : std::true_type {
+        };
 
     public:
         /**


### PR DESCRIPTION
This pull request focuses on simplifying and modernizing SFINAE (Substitution Failure Is Not An Error) patterns throughout the codebase, mainly by removing unnecessary uses of `std::enable_if` in type trait templates. Additionally, the utilities for detecting the presence of a `ToString` method have been refactored for clarity and consistency.

### SFINAE Pattern Simplification

* Removed redundant `std::enable_if` wrappers from various trait templates such as `_IsEqualityComparable`, `_BracketOperationHelper`, `_IsExplicitlyConvertable`, and related macros in `Property.h` and `Delegate.h`, streamlining the code and improving readability. [[1]](diffhunk://#diff-a4bda853a504f9ed863fb661805568da8c80439db49de0aabcefff25d722783fL401-R401) [[2]](diffhunk://#diff-a4eeca62c441fb92cd51f52dc55de7b35782aaaf5eb597eca3e7f84c4d0d61b6L11-R11) [[3]](diffhunk://#diff-a4eeca62c441fb92cd51f52dc55de7b35782aaaf5eb597eca3e7f84c4d0d61b6L22-R20) [[4]](diffhunk://#diff-a4eeca62c441fb92cd51f52dc55de7b35782aaaf5eb597eca3e7f84c4d0d61b6L116-R113) [[5]](diffhunk://#diff-a4eeca62c441fb92cd51f52dc55de7b35782aaaf5eb597eca3e7f84c4d0d61b6L133-R129) [[6]](diffhunk://#diff-a4eeca62c441fb92cd51f52dc55de7b35782aaaf5eb597eca3e7f84c4d0d61b6L167-R162)

### Utility and Trait Refactoring

* Refactored the `_HasToString` trait: replaced the old SFINAE-based detection with a more modern and consistent implementation using a template specialization inside the `Utils` class, improving maintainability and clarity.