### PR TITLE
修复cmake find_package(sw)找不到 sw包

### DIFF
--- a/sw/CMakeLists.txt
+++ b/sw/CMakeLists.txt
@@ -96,5 +96,5 @@ write_basic_package_version_file(
 install(FILES
     "${PROJECT_BINARY_DIR}/swConfig.cmake"
     "${PROJECT_BINARY_DIR}/swConfigVersion.cmake"
-    DESTINATION "share/sw-mzying2001"
+    DESTINATION "share/sw"
 )


### PR DESCRIPTION
cmake find_package查找路径是这样的$cmake_prefix_path/share/<package_name>*/ 以前的命名方式 会找不到安装到本地的 sw 包