### PR TITLE
Feature/frameworkelement

### DIFF
--- a/sw/inc/DataBinding.h
+++ b/sw/inc/DataBinding.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "UIElement.h"
+#include "FrameworkElement.h"
 
 namespace sw
 {
@@ -13,7 +13,7 @@ namespace sw
         /**
          * @brief 目标元素
          */
-        UIElement *_targetElement;
+        FrameworkElement *_targetElement;
 
         /**
          * @brief 内部绑定对象
@@ -26,7 +26,7 @@ namespace sw
          * @param targetElement 目标元素
          * @param binding 内部绑定对象
          */
-        DataBinding(UIElement *targetElement, Binding *binding)
+        DataBinding(FrameworkElement *targetElement, Binding *binding)
             : _targetElement(targetElement), _innerBinding(binding)
         {
             UpdateDataContextBinding();
@@ -80,7 +80,7 @@ namespace sw
          * @brief 获取目标元素
          * @return 目标元素指针
          */
-        UIElement *GetTargetElement() const
+        FrameworkElement *GetTargetElement() const
         {
             return _targetElement;
         }
@@ -89,7 +89,7 @@ namespace sw
          * @brief 设置目标元素
          * @param element 目标元素指针
          */
-        void SetTargetElement(UIElement *element)
+        void SetTargetElement(FrameworkElement *element)
         {
             if (_targetElement != element) {
                 UnregisterNotifications();
@@ -155,7 +155,7 @@ namespace sw
         /**
          * @brief 目标元素数据上下文更改事件处理函数
          */
-        void OnTargetElementDataContextChanged(UIElement &sender, DataContextChangedEventArgs &e)
+        void OnTargetElementDataContextChanged(FrameworkElement &sender, DataContextChangedEventArgs &e)
         {
             UpdateDataContextBinding();
         }
@@ -168,7 +168,7 @@ namespace sw
          * @return 绑定对象指针
          * @note 绑定对象不能为nullptr，其生命周期将由DataBinding管理，请勿与其他对象共享
          */
-        static DataBinding *Create(UIElement *targetElement, Binding *binding)
+        static DataBinding *Create(FrameworkElement *targetElement, Binding *binding)
         {
             assert(binding != nullptr);
             return new DataBinding(targetElement, binding);

--- a/sw/inc/FrameworkElement.h
+++ b/sw/inc/FrameworkElement.h
@@ -1,0 +1,145 @@
+#pragma once
+
+#include "Binding.h"
+#include "ObservableObject.h"
+#include <unordered_map>
+
+namespace sw
+{
+    // 前向声明
+    class DataBinding;
+    class FrameworkElement;
+
+    /**
+     * @brief 数据上下文更改事件参数
+     */
+    struct DataContextChangedEventArgs : EventArgs {
+        /**
+         * @brief 旧的数据上下文值
+         */
+        DynamicObject *oldDataContext;
+    };
+
+    /**
+     * @brief 数据上下文更改事件处理函数类型
+     */
+    using DataContextChangedEventHandler =
+        EventHandler<FrameworkElement, DataContextChangedEventArgs>;
+
+    /**
+     * @brief 框架元素类，提供数据上下文和绑定功能
+     */
+    class FrameworkElement : public ObservableObject
+    {
+    private:
+        /**
+         * @brief 属性的绑定信息
+         */
+        std::unordered_map<FieldId, std::unique_ptr<BindingBase>> _bindings{};
+
+        /**
+         * @brief 数据上下文
+         */
+        DynamicObject *_dataContext = nullptr;
+
+        /**
+         * @brief 数据上下文改变事件委托
+         */
+        DataContextChangedEventHandler _dataContextChanged;
+
+    public:
+        /**
+         * @brief 数据上下文改变时触发该事件
+         */
+        const Event<DataContextChangedEventHandler> DataContextChanged;
+
+        /**
+         * @brief 数据上下文
+         */
+        const Property<DynamicObject *> DataContext;
+
+        /**
+         * @brief 当前元素的有效数据上下文
+         * @note  若当前元素的DataContext不为nullptr则返回该值，否则递归获取父元素的DataContext
+         */
+        const ReadOnlyProperty<DynamicObject *> CurrentDataContext;
+
+    protected:
+        /**
+         * @brief 初始化FrameworkElement
+         */
+        FrameworkElement();
+
+        // 删除拷贝构造函数
+        FrameworkElement(const FrameworkElement &) = delete;
+
+        // 删除移动构造函数
+        FrameworkElement(FrameworkElement &&) = delete;
+
+        // 删除拷贝赋值运算符
+        FrameworkElement &operator=(const FrameworkElement &) = delete;
+
+        // 删除移动赋值运算符
+        FrameworkElement &operator=(FrameworkElement &&) = delete;
+
+    public:
+        /**
+         * @brief  添加绑定对象
+         * @return 若函数成功则返回true，否则返回false
+         * @note   绑定对象的生命周期将由当前元素管理，请勿与其他对象共享
+         * @note   请确保绑定对象的目标属性为当前元素的属性，该函数内部不会对此进行检查
+         * @note   同一个属性只能设置一个绑定，若该属性已存在绑定则会被新的绑定覆盖
+         */
+        bool AddBinding(BindingBase *binding);
+
+        /**
+         * @brief  添加绑定对象
+         * @return 若函数成功则返回true，否则返回false
+         * @note   绑定对象的生命周期将由当前元素管理，请勿与其他对象共享
+         * @note   该函数会将绑定的目标对象设置为当前元素，若未指定源对象则会将DataContext作为源对象
+         * @note   同一个属性只能设置一个绑定，若该属性已存在绑定则会被新的绑定覆盖
+         */
+        bool AddBinding(Binding *binding);
+
+        /**
+         * @brief  添加绑定到DataContext的绑定对象
+         * @return 若函数成功则返回true，否则返回false
+         * @note   绑定对象的生命周期将由当前元素管理，请勿与其他对象共享
+         * @note   同一个属性只能设置一个绑定，若该属性已存在绑定则会被新的绑定覆盖
+         */
+        bool AddBinding(DataBinding *binding);
+
+        /**
+         * @brief  移除指定属性的绑定对象
+         * @return 若函数成功则返回true，否则返回false
+         */
+        bool RemoveBinding(FieldId propertyId);
+
+    protected:
+        /**
+         * @brief 当CurrentDataContext更改时调用此函数
+         * @param oldDataContext 旧的数据上下文值
+         */
+        virtual void OnCurrentDataContextChanged(DynamicObject *oldDataContext);
+
+    public:
+        /**
+         * @brief 获取父元素
+         * @return 父元素指针，如果没有父元素则返回nullptr
+         */
+        virtual FrameworkElement *GetParent() const = 0;
+
+        /**
+         * @brief 获取子元素数量
+         * @return 子元素数量
+         */
+        virtual int GetChildCount() const = 0;
+
+        /**
+         * @brief 获取指定索引处的子元素
+         * @param index 子元素索引
+         * @throw std::out_of_range 如果索引超出范围
+         */
+        virtual FrameworkElement &GetChildAt(int index) const = 0;
+    };
+}

--- a/sw/inc/FrameworkElement.h
+++ b/sw/inc/FrameworkElement.h
@@ -60,7 +60,7 @@ namespace sw
 
         /**
          * @brief 当前元素的有效数据上下文
-         * @note  若当前元素的DataContext不为nullptr则返回该值，否则递归获取父元素的DataContext
+         * @note 若当前元素的DataContext不为nullptr则返回该值，否则递归获取父元素的DataContext
          */
         const ReadOnlyProperty<DynamicObject *> CurrentDataContext;
 
@@ -84,36 +84,44 @@ namespace sw
 
     public:
         /**
-         * @brief  添加绑定对象
+         * @brief 添加绑定对象
          * @return 若函数成功则返回true，否则返回false
-         * @note   绑定对象的生命周期将由当前元素管理，请勿与其他对象共享
-         * @note   请确保绑定对象的目标属性为当前元素的属性，该函数内部不会对此进行检查
-         * @note   同一个属性只能设置一个绑定，若该属性已存在绑定则会被新的绑定覆盖
+         * @note 绑定对象的生命周期将由当前元素管理，请勿与其他对象共享
+         * @note 请确保绑定对象的目标属性为当前元素的属性，该函数内部不会对此进行检查
+         * @note 同一个属性只能设置一个绑定，若该属性已存在绑定则会被新的绑定覆盖
          */
         bool AddBinding(BindingBase *binding);
 
         /**
-         * @brief  添加绑定对象
+         * @brief 添加绑定对象
          * @return 若函数成功则返回true，否则返回false
-         * @note   绑定对象的生命周期将由当前元素管理，请勿与其他对象共享
-         * @note   该函数会将绑定的目标对象设置为当前元素，若未指定源对象则会将DataContext作为源对象
-         * @note   同一个属性只能设置一个绑定，若该属性已存在绑定则会被新的绑定覆盖
+         * @note 绑定对象的生命周期将由当前元素管理，请勿与其他对象共享
+         * @note 该函数会将绑定的目标对象设置为当前元素，若未指定源对象则会将DataContext作为源对象
+         * @note 同一个属性只能设置一个绑定，若该属性已存在绑定则会被新的绑定覆盖
          */
         bool AddBinding(Binding *binding);
 
         /**
-         * @brief  添加绑定到DataContext的绑定对象
+         * @brief 添加绑定到DataContext的绑定对象
          * @return 若函数成功则返回true，否则返回false
-         * @note   绑定对象的生命周期将由当前元素管理，请勿与其他对象共享
-         * @note   同一个属性只能设置一个绑定，若该属性已存在绑定则会被新的绑定覆盖
+         * @note 绑定对象的生命周期将由当前元素管理，请勿与其他对象共享
+         * @note 同一个属性只能设置一个绑定，若该属性已存在绑定则会被新的绑定覆盖
          */
         bool AddBinding(DataBinding *binding);
+
+        /**
+         * @brief 移除指定属性的绑定对象
+         * @return 若函数成功则返回true，否则返回false
+         */
+        bool RemoveBinding(FieldId propertyId);
 
         /**
          * @brief  移除指定属性的绑定对象
          * @return 若函数成功则返回true，否则返回false
          */
-        bool RemoveBinding(FieldId propertyId);
+        template <typename T, typename TProperty>
+        bool RemoveBinding(TProperty T::*prop)
+        { return RemoveBinding(Reflection::GetFieldId(prop)); }
 
     protected:
         /**

--- a/sw/inc/ILayout.h
+++ b/sw/inc/ILayout.h
@@ -30,8 +30,9 @@ namespace sw
 
         /**
          * @brief 获取对应索引处的子控件
+         * @throw std::out_of_range 如果索引超出范围
          */
-        virtual ILayout &GetChildLayoutAt(int index) = 0;
+        virtual ILayout &GetChildLayoutAt(int index) const = 0;
 
         /**
          * @brief 获取控件所需尺寸
@@ -39,13 +40,13 @@ namespace sw
         virtual Size GetDesireSize() const = 0;
 
         /**
-         * @brief               测量控件所需尺寸
+         * @brief 测量控件所需尺寸
          * @param availableSize 可用的尺寸
          */
         virtual void Measure(const Size &availableSize) = 0;
 
         /**
-         * @brief               安排控件位置
+         * @brief 安排控件位置
          * @param finalPosition 最终控件所安排的位置
          */
         virtual void Arrange(const Rect &finalPosition) = 0;

--- a/sw/inc/LayoutHost.h
+++ b/sw/inc/LayoutHost.h
@@ -22,37 +22,38 @@ namespace sw
         virtual ~LayoutHost() = default;
 
         /**
-         * @brief     设置关联的对象，每个LayoutHost只能关联一个对象
+         * @brief 设置关联的对象，每个LayoutHost只能关联一个对象
          * @param obj 要关联的对象
          */
         void Associate(ILayout *obj);
 
         /**
-         * @brief     判断当前LayoutHost是否关联了对象
+         * @brief 判断当前LayoutHost是否关联了对象
          * @param obj 若传入值为nullptr，则判断是否有任何对象关联，否则判断是否关联了指定对象
          */
-        bool IsAssociated(ILayout *obj = nullptr);
+        bool IsAssociated(ILayout *obj = nullptr) const;
 
         /**
          * @brief 获取关联对象子控件的数量
          */
-        int GetChildLayoutCount();
+        int GetChildLayoutCount() const;
 
         /**
          * @brief 获取关联对象对应索引处的子控件
+         * @throw std::out_of_range 如果索引超出范围
          */
-        ILayout &GetChildLayoutAt(int index);
+        ILayout &GetChildLayoutAt(int index) const;
 
     public:
         /**
-         * @brief               测量元素所需尺寸，无需考虑边框和边距
+         * @brief 测量元素所需尺寸，无需考虑边框和边距
          * @param availableSize 可用的尺寸
-         * @return              返回元素需要占用的尺寸
+         * @return 返回元素需要占用的尺寸
          */
         virtual Size MeasureOverride(const Size &availableSize) = 0;
 
         /**
-         * @brief           安排子元素的位置，可重写该函数以实现自定义布局
+         * @brief 安排子元素的位置，可重写该函数以实现自定义布局
          * @param finalSize 可用于排列子元素的最终尺寸
          */
         virtual void ArrangeOverride(const Size &finalSize) = 0;

--- a/sw/inc/SimpleWindow.h
+++ b/sw/inc/SimpleWindow.h
@@ -36,6 +36,7 @@
 #include "FolderDialog.h"
 #include "Font.h"
 #include "FontDialog.h"
+#include "FrameworkElement.h"
 #include "Grid.h"
 #include "GridLayout.h"
 #include "GroupBox.h"

--- a/sw/inc/UIElement.h
+++ b/sw/inc/UIElement.h
@@ -659,9 +659,10 @@ namespace sw
 
         /**
          * @brief 获取对应索引处的子元素，只索引参与布局的子元素
+         * @throw std::out_of_range 如果索引超出范围
          * @note  参与布局的子元素：即非collapsed状态的元素
          */
-        virtual ILayout &GetChildLayoutAt(int index) override final;
+        virtual ILayout &GetChildLayoutAt(int index) const override final;
 
         /**
          * @brief 获取当前元素所需尺寸

--- a/sw/inc/UIElement.h
+++ b/sw/inc/UIElement.h
@@ -26,22 +26,6 @@ namespace sw
     class DataBinding;
 
     /**
-     * @brief 数据上下文更改事件参数
-     */
-    struct DataContextChangedEventArgs : EventArgs {
-        /**
-         * @brief 旧的数据上下文值
-         */
-        DynamicObject *oldDataContext;
-    };
-
-    /**
-     * @brief 数据上下文更改事件处理函数类型
-     */
-    using DataContextChangedEventHandler =
-        EventHandler<UIElement, DataContextChangedEventArgs>;
-
-    /**
      * @brief 通知布局更新的条件
      */
     enum class LayoutUpdateCondition : uint32_t {
@@ -285,22 +269,7 @@ namespace sw
          */
         std::unordered_map<FieldId, std::unique_ptr<BindingBase>> _bindings{};
 
-        /**
-         * @brief 数据上下文
-         */
-        DynamicObject *_dataContext = nullptr;
-
-        /**
-         * @brief 数据上下文改变事件委托
-         */
-        DataContextChangedEventHandler _dataContextChanged;
-
     public:
-        /**
-         * @brief 数据上下文改变时触发该事件
-         */
-        const Event<DataContextChangedEventHandler> DataContextChanged;
-
         /**
          * @brief 边距
          */
@@ -424,17 +393,6 @@ namespace sw
          */
         const ReadOnlyProperty<bool> IsFocusedViaTab;
 
-        /**
-         * @brief 数据上下文
-         */
-        const Property<DynamicObject *> DataContext;
-
-        /**
-         * @brief 当前元素的有效数据上下文
-         * @note  若当前元素的DataContext不为nullptr则返回该值，否则递归获取父元素的DataContext
-         */
-        const ReadOnlyProperty<DynamicObject *> CurrentDataContext;
-
     public:
         /**
          * @brief 初始化UIElement
@@ -481,11 +439,6 @@ namespace sw
          * @param eventType 路由事件类型
          */
         bool IsRoutedEventRegistered(RoutedEventType eventType);
-
-        /**
-         * @brief 获取子元素
-         */
-        UIElement &GetChildAt(int index) const;
 
         /**
          * @brief  添加子元素
@@ -665,36 +618,23 @@ namespace sw
         bool BringIntoView();
 
         /**
-         * @brief  添加绑定对象
-         * @return 若函数成功则返回true，否则返回false
-         * @note   绑定对象的生命周期将由当前元素管理，请勿与其他对象共享
-         * @note   请确保绑定对象的目标属性为当前元素的属性，该函数内部不会对此进行检查
-         * @note   同一个属性只能设置一个绑定，若该属性已存在绑定则会被新的绑定覆盖
+         * @brief  获取父元素
+         * @return 父元素指针，如果没有父元素则返回nullptr
          */
-        bool AddBinding(BindingBase *binding);
+        virtual UIElement *GetParent() const override final;
 
         /**
-         * @brief  添加绑定对象
-         * @return 若函数成功则返回true，否则返回false
-         * @note   绑定对象的生命周期将由当前元素管理，请勿与其他对象共享
-         * @note   该函数会将绑定的目标对象设置为当前元素，若未指定源对象则会将DataContext作为源对象
-         * @note   同一个属性只能设置一个绑定，若该属性已存在绑定则会被新的绑定覆盖
+         * @brief  获取子元素数量
+         * @return 子元素数量
          */
-        bool AddBinding(Binding *binding);
+        virtual int GetChildCount() const override final;
 
         /**
-         * @brief  添加绑定到DataContext的绑定对象
-         * @return 若函数成功则返回true，否则返回false
-         * @note   绑定对象的生命周期将由当前元素管理，请勿与其他对象共享
-         * @note   同一个属性只能设置一个绑定，若该属性已存在绑定则会被新的绑定覆盖
+         * @brief       获取指定索引处的子元素
+         * @param index 子元素索引
+         * @throw       std::out_of_range 如果索引超出范围
          */
-        bool AddBinding(DataBinding *binding);
-
-        /**
-         * @brief  移除指定属性的绑定对象
-         * @return 若函数成功则返回true，否则返回false
-         */
-        bool RemoveBinding(FieldId propertyId);
+        virtual UIElement &GetChildAt(int index) const override final;
 
         /**
          * @brief 获取Tag
@@ -1123,17 +1063,6 @@ namespace sw
          * @brief 从_layoutVisibleChildren中移除指定元素
          */
         void _RemoveFromLayoutVisibleChildren(UIElement *element);
-
-        /**
-         * @brief  获取当前元素的有效数据上下文
-         * @return 若当前元素的DataContext不为nullptr则返回该值，否则递归获取父元素的DataContext
-         */
-        DynamicObject *_GetCurrentDataContext();
-
-        /**
-         * @brief 当CurrentDataContext更改时调用此函数
-         */
-        void _OnCurrentDataContextChanged(DynamicObject *oldval);
 
         /**
          * @brief 循环获取界面树上的下一个节点

--- a/sw/inc/UIElement.h
+++ b/sw/inc/UIElement.h
@@ -1379,16 +1379,6 @@ namespace sw
                 return this->RemoveHandler(eventType, RoutedEventHandlerWrapper<TEventArgs>(Action<UIElement &, TEventArgs &>(obj, handler)));
             }
         }
-
-        /**
-         * @brief  移除指定属性的绑定对象
-         * @return 若函数成功则返回true，否则返回false
-         */
-        template <typename T, typename TProperty>
-        bool RemoveBinding(TProperty T::*prop)
-        {
-            return this->RemoveBinding(Reflection::GetFieldId(prop));
-        }
     };
 
     /**

--- a/sw/inc/UIElement.h
+++ b/sw/inc/UIElement.h
@@ -655,13 +655,13 @@ namespace sw
          * @brief 获取参与布局的子元素数量
          * @note  参与布局的子元素：即非collapsed状态的元素
          */
-        virtual int GetChildLayoutCount() const override;
+        virtual int GetChildLayoutCount() const override final;
 
         /**
          * @brief 获取对应索引处的子元素，只索引参与布局的子元素
          * @note  参与布局的子元素：即非collapsed状态的元素
          */
-        virtual ILayout &GetChildLayoutAt(int index) override;
+        virtual ILayout &GetChildLayoutAt(int index) override final;
 
         /**
          * @brief 获取当前元素所需尺寸
@@ -684,7 +684,7 @@ namespace sw
          * @brief  尝试将对象转换成UIElement
          * @return 若函数成功则返回UIElement指针，否则返回nullptr
          */
-        virtual UIElement *ToUIElement() override;
+        virtual UIElement *ToUIElement() override final;
 
     protected:
         /**

--- a/sw/inc/WndBase.h
+++ b/sw/inc/WndBase.h
@@ -5,11 +5,11 @@
 #include "Delegate.h"
 #include "Dip.h"
 #include "Font.h"
+#include "FrameworkElement.h"
 #include "HitTestResult.h"
 #include "IComparable.h"
 #include "IToString.h"
 #include "Keys.h"
-#include "ObservableObject.h"
 #include "Point.h"
 #include "ProcMsg.h"
 #include "Property.h"
@@ -30,7 +30,7 @@ namespace sw
     /**
      * @brief 表示一个Windows窗口，是所有窗口和控件的基类
      */
-    class WndBase : public ObservableObject,
+    class WndBase : public FrameworkElement,
                     public IToString<WndBase>,
                     public IEqualityComparable<WndBase>
     {
@@ -178,11 +178,6 @@ namespace sw
         const Property<bool> Focused;
 
         /**
-         * @brief 父窗口
-         */
-        const ReadOnlyProperty<WndBase *> Parent;
-
-        /**
          * @brief 是否已销毁，当该值为true时不应该继续使用当前对象
          */
         const ReadOnlyProperty<bool> IsDestroyed;
@@ -219,11 +214,6 @@ namespace sw
          */
         WndBase();
 
-        WndBase(const WndBase &)            = delete; // 删除拷贝构造函数
-        WndBase(WndBase &&)                 = delete; // 删除移动构造函数
-        WndBase &operator=(const WndBase &) = delete; // 删除拷贝赋值运算符
-        WndBase &operator=(WndBase &&)      = delete; // 删除移动赋值运算符
-
     public:
         /**
          * @brief 析构函数，这里用纯虚函数使该类成为抽象类
@@ -257,6 +247,25 @@ namespace sw
          * @brief 获取当前对象的描述字符串
          */
         virtual std::wstring ToString() const;
+
+        /**
+         * @brief  获取父元素
+         * @return 父元素指针，如果没有父元素则返回nullptr
+         */
+        virtual FrameworkElement *GetParent() const override;
+
+        /**
+         * @brief  获取子元素数量
+         * @return 子元素数量
+         */
+        virtual int GetChildCount() const override;
+
+        /**
+         * @brief       获取指定索引处的子元素
+         * @param index 子元素索引
+         * @throw       std::out_of_range 如果索引超出范围
+         */
+        virtual FrameworkElement &GetChildAt(int index) const override;
 
     protected:
         /**

--- a/sw/src/Control.cpp
+++ b/sw/src/Control.cpp
@@ -14,7 +14,7 @@ sw::Control::Control()
                       return false;
                   }
                   auto container = WndBase::_GetControlInitContainer();
-                  return container == nullptr || GetParent(self->_hwnd) != container->_hwnd;
+                  return container == nullptr || ::GetParent(self->_hwnd) != container->_hwnd;
               }))
 {
 }
@@ -45,7 +45,7 @@ bool sw::Control::ResetHandle(DWORD style, DWORD exStyle, LPVOID lpParam)
     auto text = GetInternalText().c_str();
 
     HWND oldHwnd = _hwnd;
-    HWND hParent = GetParent(oldHwnd);
+    HWND hParent = ::GetParent(oldHwnd);
 
     wchar_t className[256];
     GetClassNameW(oldHwnd, className, 256);

--- a/sw/src/FrameworkElement.cpp
+++ b/sw/src/FrameworkElement.cpp
@@ -1,0 +1,112 @@
+#include "FrameworkElement.h"
+#include "DataBinding.h"
+
+sw::FrameworkElement::FrameworkElement()
+    : DataContextChanged(
+          Event<DataContextChangedEventHandler>::Init(this)
+              .Delegate([](FrameworkElement *self) -> DataContextChangedEventHandler & {
+                  return self->_dataContextChanged;
+              })),
+
+      DataContext(
+          Property<DynamicObject *>::Init(this)
+              .Getter([](FrameworkElement *self) -> DynamicObject * {
+                  return self->_dataContext;
+              })
+              .Setter([](FrameworkElement *self, DynamicObject *value) {
+                  if (self->_dataContext != value) {
+                      auto oldDataContext = self->CurrentDataContext.Get();
+                      self->_dataContext  = value;
+                      self->RaisePropertyChanged(&FrameworkElement::DataContext);
+                      if (oldDataContext != value) {
+                          self->OnCurrentDataContextChanged(oldDataContext);
+                      }
+                  }
+              })),
+
+      CurrentDataContext(
+          Property<DynamicObject *>::Init(this)
+              .Getter([](FrameworkElement *self) -> DynamicObject * {
+                  DynamicObject *result     = nullptr;
+                  FrameworkElement *element = self;
+                  do {
+                      result  = element->_dataContext;
+                      element = element->GetParent();
+                  } while (result == nullptr && element != nullptr);
+                  return result;
+              }))
+{
+}
+
+bool sw::FrameworkElement::AddBinding(BindingBase *binding)
+{
+    if (binding == nullptr) {
+        return false;
+    } else {
+        this->_bindings[binding->GetTargetPropertyId()].reset(binding);
+        return true;
+    }
+}
+
+bool sw::FrameworkElement::AddBinding(Binding *binding)
+{
+    if (binding == nullptr) {
+        return false;
+    }
+    if (binding->GetSourceObject() == nullptr) {
+        auto dataBinding = DataBinding::Create(this, binding);
+        return this->AddBinding(static_cast<BindingBase *>(dataBinding));
+    } else {
+        binding->SetTargetObject(this);
+        return this->AddBinding(static_cast<BindingBase *>(binding));
+    }
+}
+
+bool sw::FrameworkElement::AddBinding(DataBinding *binding)
+{
+    if (binding == nullptr) {
+        return false;
+    } else {
+        binding->SetTargetElement(this);
+        return this->AddBinding(static_cast<BindingBase *>(binding));
+    }
+}
+
+bool sw::FrameworkElement::RemoveBinding(FieldId propertyId)
+{
+    if (this->_bindings.count(propertyId) == 0) {
+        return false;
+    } else {
+        this->_bindings.erase(propertyId);
+        return true;
+    }
+}
+
+void sw::FrameworkElement::OnCurrentDataContextChanged(DynamicObject *oldDataContext)
+{
+    std::vector<FrameworkElement *> stack;
+    stack.push_back(this);
+
+    while (!stack.empty()) {
+        auto current = stack.back();
+        stack.pop_back();
+
+        current->RaisePropertyChanged(
+            &FrameworkElement::CurrentDataContext);
+
+        if (current->_dataContextChanged) {
+            DataContextChangedEventArgs args{};
+            args.oldDataContext = oldDataContext;
+            current->_dataContextChanged(*current, args);
+        }
+
+        int childCount = current->GetChildCount();
+
+        for (int i = 0; i < childCount; i++) {
+            auto &child = current->GetChildAt(i);
+            if (child._dataContext == nullptr) {
+                stack.push_back(&child);
+            }
+        }
+    }
+}

--- a/sw/src/LayoutHost.cpp
+++ b/sw/src/LayoutHost.cpp
@@ -5,19 +5,19 @@ void sw::LayoutHost::Associate(ILayout *obj)
     this->_associatedObj = obj;
 }
 
-bool sw::LayoutHost::IsAssociated(ILayout *obj)
+bool sw::LayoutHost::IsAssociated(ILayout *obj) const
 {
     return obj == nullptr
                ? (this->_associatedObj != nullptr)
                : (this->_associatedObj == obj);
 }
 
-int sw::LayoutHost::GetChildLayoutCount()
+int sw::LayoutHost::GetChildLayoutCount() const
 {
     return this->_associatedObj->GetChildLayoutCount();
 }
 
-sw::ILayout &sw::LayoutHost::GetChildLayoutAt(int index)
+sw::ILayout &sw::LayoutHost::GetChildLayoutAt(int index) const
 {
     return this->_associatedObj->GetChildLayoutAt(index);
 }

--- a/sw/src/UIElement.cpp
+++ b/sw/src/UIElement.cpp
@@ -774,7 +774,7 @@ int sw::UIElement::GetChildLayoutCount() const
     return static_cast<int>(this->_layoutVisibleChildren.size());
 }
 
-sw::ILayout &sw::UIElement::GetChildLayoutAt(int index)
+sw::ILayout &sw::UIElement::GetChildLayoutAt(int index) const
 {
     return *this->_layoutVisibleChildren.at(index);
 }

--- a/sw/src/UIElement.cpp
+++ b/sw/src/UIElement.cpp
@@ -15,7 +15,7 @@ namespace
     const sw::FieldId _PropId_VerticalAlignment   = sw::Reflection::GetFieldId(&sw::UIElement::VerticalAlignment);
     const sw::FieldId _PropId_ChildCount          = sw::Reflection::GetFieldId(&sw::UIElement::ChildCount);
     const sw::FieldId _PropId_CollapseWhenHide    = sw::Reflection::GetFieldId(&sw::UIElement::CollapseWhenHide);
-    const sw::FieldId _PropId_UIElementParent     = sw::Reflection::GetFieldId(&sw::UIElement::Parent);
+    const sw::FieldId _PropId_Parent              = sw::Reflection::GetFieldId(&sw::UIElement::Parent);
     const sw::FieldId _PropId_Tag                 = sw::Reflection::GetFieldId(&sw::UIElement::Tag);
     const sw::FieldId _PropId_LayoutTag           = sw::Reflection::GetFieldId(&sw::UIElement::LayoutTag);
     const sw::FieldId _PropId_ContextMenu         = sw::Reflection::GetFieldId(&sw::UIElement::ContextMenu);
@@ -31,18 +31,10 @@ namespace
     const sw::FieldId _PropId_MaxHeight           = sw::Reflection::GetFieldId(&sw::UIElement::MaxHeight);
     const sw::FieldId _PropId_LogicalRect         = sw::Reflection::GetFieldId(&sw::UIElement::LogicalRect);
     const sw::FieldId _PropId_IsHitTestVisible    = sw::Reflection::GetFieldId(&sw::UIElement::IsHitTestVisible);
-    const sw::FieldId _PropId_DataContext         = sw::Reflection::GetFieldId(&sw::UIElement::DataContext);
-    const sw::FieldId _PropId_CurrentDataContext  = sw::Reflection::GetFieldId(&sw::UIElement::CurrentDataContext);
 }
 
 sw::UIElement::UIElement()
-    : DataContextChanged(
-          Event<DataContextChangedEventHandler>::Init(this)
-              .Delegate([](UIElement *self) -> DataContextChangedEventHandler & {
-                  return self->_dataContextChanged;
-              })),
-
-      Margin(
+    : Margin(
           Property<Thickness>::Init(this)
               .Getter([](UIElement *self) -> Thickness {
                   return self->_margin;
@@ -102,7 +94,7 @@ sw::UIElement::UIElement()
       Parent(
           Property<UIElement *>::Init(this)
               .Getter([](UIElement *self) -> UIElement * {
-                  return self->_parent;
+                  return self->GetParent();
               })),
 
       Tag(
@@ -306,28 +298,6 @@ sw::UIElement::UIElement()
           Property<bool>::Init(this)
               .Getter([](UIElement *self) -> bool {
                   return self->_focusedViaTab;
-              })),
-
-      DataContext(
-          Property<DynamicObject *>::Init(this)
-              .Getter([](UIElement *self) -> DynamicObject * {
-                  return self->_dataContext;
-              })
-              .Setter([](UIElement *self, DynamicObject *value) {
-                  if (self->_dataContext != value) {
-                      auto oldDataContext = self->_GetCurrentDataContext();
-                      self->_dataContext  = value;
-                      self->RaisePropertyChanged(_PropId_DataContext);
-                      if (oldDataContext != value) {
-                          self->_OnCurrentDataContextChanged(oldDataContext);
-                      }
-                  }
-              })),
-
-      CurrentDataContext(
-          Property<DynamicObject *>::Init(this)
-              .Getter([](UIElement *self) -> DynamicObject * {
-                  return self->_GetCurrentDataContext();
               }))
 {
 }
@@ -366,11 +336,6 @@ void sw::UIElement::UnregisterRoutedEvent(RoutedEventType eventType)
 bool sw::UIElement::IsRoutedEventRegistered(RoutedEventType eventType)
 {
     return this->_eventMap[eventType] != nullptr;
-}
-
-sw::UIElement &sw::UIElement::GetChildAt(int index) const
-{
-    return *this->_children.at(index);
 }
 
 bool sw::UIElement::AddChild(UIElement *element)
@@ -771,47 +736,19 @@ bool sw::UIElement::BringIntoView()
     return false;
 }
 
-bool sw::UIElement::AddBinding(BindingBase *binding)
+sw::UIElement *sw::UIElement::GetParent() const
 {
-    if (binding == nullptr) {
-        return false;
-    } else {
-        this->_bindings[binding->GetTargetPropertyId()].reset(binding);
-        return true;
-    }
+    return this->_parent;
 }
 
-bool sw::UIElement::AddBinding(Binding *binding)
+int sw::UIElement::GetChildCount() const
 {
-    if (binding == nullptr) {
-        return false;
-    }
-    if (binding->GetSourceObject() == nullptr) {
-        auto dataBinding = DataBinding::Create(this, binding);
-        return this->AddBinding(static_cast<BindingBase *>(dataBinding));
-    } else {
-        binding->SetTargetObject(this);
-        return this->AddBinding(static_cast<BindingBase *>(binding));
-    }
+    return static_cast<int>(this->_children.size());
 }
 
-bool sw::UIElement::AddBinding(DataBinding *binding)
+sw::UIElement &sw::UIElement::GetChildAt(int index) const
 {
-    if (binding == nullptr) {
-        return false;
-    }
-    binding->SetTargetElement(this);
-    return this->AddBinding(static_cast<BindingBase *>(binding));
-}
-
-bool sw::UIElement::RemoveBinding(FieldId propertyId)
-{
-    if (this->_bindings.count(propertyId) == 0) {
-        return false;
-    } else {
-        this->_bindings.erase(propertyId);
-        return true;
-    }
+    return *this->_children.at(index);
 }
 
 uint64_t sw::UIElement::GetTag() const
@@ -1293,16 +1230,16 @@ bool sw::UIElement::SetParent(WndBase *parent)
 
 void sw::UIElement::ParentChanged(WndBase *newParent)
 {
-    auto oldDataContext = this->_GetCurrentDataContext();
+    auto oldDataContext = this->CurrentDataContext.Get();
 
     this->_parent = newParent ? newParent->ToUIElement() : nullptr;
     this->_SetMeasureInvalidated();
 
-    this->WndBase::ParentChanged(newParent); // raise property WndBase::Parent changed event
-    this->RaisePropertyChanged(_PropId_UIElementParent);
+    this->WndBase::ParentChanged(newParent);
+    this->RaisePropertyChanged(_PropId_Parent);
 
-    if (this->_GetCurrentDataContext() != oldDataContext) {
-        this->_OnCurrentDataContextChanged(oldDataContext);
+    if (this->CurrentDataContext != oldDataContext) {
+        this->OnCurrentDataContextChanged(oldDataContext);
     }
 }
 
@@ -1614,42 +1551,6 @@ void sw::UIElement::_RemoveFromLayoutVisibleChildren(UIElement *element)
 
     if (it != this->_layoutVisibleChildren.end()) {
         this->_layoutVisibleChildren.erase(it);
-    }
-}
-
-sw::DynamicObject *sw::UIElement::_GetCurrentDataContext()
-{
-    DynamicObject *result = nullptr;
-    UIElement *element    = this;
-    do {
-        result  = element->_dataContext;
-        element = element->_parent;
-    } while (result == nullptr && element != nullptr);
-    return result;
-}
-
-void sw::UIElement::_OnCurrentDataContextChanged(DynamicObject *oldval)
-{
-    std::vector<UIElement *> stack;
-    stack.push_back(this);
-
-    while (!stack.empty()) {
-        auto current = stack.back();
-        stack.pop_back();
-
-        current->RaisePropertyChanged(_PropId_CurrentDataContext);
-
-        if (current->_dataContextChanged) {
-            DataContextChangedEventArgs args{};
-            args.oldDataContext = oldval;
-            current->_dataContextChanged(*current, args);
-        }
-
-        for (UIElement *child : current->_children) {
-            if (child->_dataContext == nullptr) {
-                stack.push_back(child);
-            }
-        }
     }
 }
 

--- a/sw/src/UIElement.cpp
+++ b/sw/src/UIElement.cpp
@@ -72,7 +72,7 @@ sw::UIElement::UIElement()
       ChildCount(
           Property<int>::Init(this)
               .Getter([](UIElement *self) -> int {
-                  return (int)self->_children.size();
+                  return self->GetChildCount();
               })),
 
       CollapseWhenHide(
@@ -771,12 +771,12 @@ uint64_t sw::UIElement::GetLayoutTag() const
 
 int sw::UIElement::GetChildLayoutCount() const
 {
-    return (int)this->_layoutVisibleChildren.size();
+    return static_cast<int>(this->_layoutVisibleChildren.size());
 }
 
 sw::ILayout &sw::UIElement::GetChildLayoutAt(int index)
 {
-    return *this->_layoutVisibleChildren[index];
+    return *this->_layoutVisibleChildren.at(index);
 }
 
 sw::Size sw::UIElement::GetDesireSize() const

--- a/sw/src/WndBase.cpp
+++ b/sw/src/WndBase.cpp
@@ -42,7 +42,6 @@ namespace
     const sw::FieldId _PropId_Visible      = sw::Reflection::GetFieldId(&sw::WndBase::Visible);
     const sw::FieldId _PropId_Text         = sw::Reflection::GetFieldId(&sw::WndBase::Text);
     const sw::FieldId _PropId_Focused      = sw::Reflection::GetFieldId(&sw::WndBase::Focused);
-    const sw::FieldId _PropId_Parent       = sw::Reflection::GetFieldId(&sw::WndBase::Parent);
     const sw::FieldId _PropId_IsDestroyed  = sw::Reflection::GetFieldId(&sw::WndBase::IsDestroyed);
     const sw::FieldId _PropId_AcceptFiles  = sw::Reflection::GetFieldId(&sw::WndBase::AcceptFiles);
     const sw::FieldId _PropId_IsGroupStart = sw::Reflection::GetFieldId(&sw::WndBase::IsGroupStart);
@@ -238,13 +237,6 @@ sw::WndBase::WndBase()
                   SetFocus(value ? self->_hwnd : NULL);
               })),
 
-      Parent(
-          Property<WndBase *>::Init(this)
-              .Getter([](WndBase *self) -> WndBase * {
-                  HWND hwnd = GetParent(self->_hwnd);
-                  return WndBase::GetWndBase(hwnd);
-              })),
-
       IsDestroyed(
           Property<bool>::Init(this)
               .Getter([](WndBase *self) -> bool {
@@ -334,6 +326,22 @@ bool sw::WndBase::Equals(const WndBase &other) const
 std::wstring sw::WndBase::ToString() const
 {
     return L"WndBase{ClassName=" + this->ClassName + L", Handle=" + std::to_wstring(reinterpret_cast<uintptr_t>(this->_hwnd)) + L"}";
+}
+
+sw::FrameworkElement *sw::WndBase::GetParent() const
+{
+    HWND hwnd = ::GetParent(this->_hwnd);
+    return WndBase::GetWndBase(hwnd);
+}
+
+int sw::WndBase::GetChildCount() const
+{
+    return 0;
+}
+
+sw::FrameworkElement &sw::WndBase::GetChildAt(int index) const
+{
+    throw std::out_of_range("WndBase does not maintain child elements.");
 }
 
 void sw::WndBase::InitWindow(LPCWSTR lpWindowName, DWORD dwStyle, DWORD dwExStyle)
@@ -986,7 +994,6 @@ bool sw::WndBase::SetParent(WndBase *parent)
 
 void sw::WndBase::ParentChanged(WndBase *newParent)
 {
-    this->RaisePropertyChanged(_PropId_Parent);
 }
 
 void sw::WndBase::OnCommand(int code)

--- a/vs/sw.vcxproj
+++ b/vs/sw.vcxproj
@@ -324,6 +324,7 @@
     <ClInclude Include="..\sw\inc\FolderDialog.h" />
     <ClInclude Include="..\sw\inc\Font.h" />
     <ClInclude Include="..\sw\inc\FontDialog.h" />
+    <ClInclude Include="..\sw\inc\FrameworkElement.h" />
     <ClInclude Include="..\sw\inc\Grid.h" />
     <ClInclude Include="..\sw\inc\GridLayout.h" />
     <ClInclude Include="..\sw\inc\GroupBox.h" />
@@ -437,6 +438,7 @@
     <ClCompile Include="..\sw\src\FolderDialog.cpp" />
     <ClCompile Include="..\sw\src\Font.cpp" />
     <ClCompile Include="..\sw\src\FontDialog.cpp" />
+    <ClCompile Include="..\sw\src\FrameworkElement.cpp" />
     <ClCompile Include="..\sw\src\Grid.cpp" />
     <ClCompile Include="..\sw\src\GridLayout.cpp" />
     <ClCompile Include="..\sw\src\GroupBox.cpp" />

--- a/vs/sw.vcxproj.filters
+++ b/vs/sw.vcxproj.filters
@@ -369,6 +369,9 @@
     <ClInclude Include="..\sw\inc\Event.h">
       <Filter>inc</Filter>
     </ClInclude>
+    <ClInclude Include="..\sw\inc\FrameworkElement.h">
+      <Filter>inc</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\sw\src\Animation.cpp">
@@ -636,6 +639,9 @@
       <Filter>src</Filter>
     </ClCompile>
     <ClCompile Include="..\sw\src\NotifyIcon.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\sw\src\FrameworkElement.cpp">
       <Filter>src</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
This pull request introduces a significant architectural refactor to the data binding and UI element hierarchy in the codebase. The main change is the introduction of a new `FrameworkElement` class, which now handles data context and binding responsibilities that were previously part of `UIElement`. As a result, data binding APIs and related event handling have been moved from `UIElement` to `FrameworkElement`, and the window/control base class (`WndBase`) is updated to inherit from `FrameworkElement`. This refactor brings clearer separation of concerns and aligns the architecture more closely with modern UI frameworks.

Key changes include:

**1. Introduction of `FrameworkElement` and Data Binding Refactor**
- Added a new `FrameworkElement` class that encapsulates data context, data context change events, and binding management. All data binding APIs and event types have been moved from `UIElement` to this new base class. (`sw/inc/FrameworkElement.h`, `sw/inc/DataBinding.h`, `sw/inc/UIElement.h`) [[1]](diffhunk://#diff-e42bcd5036005a4e0c7884882ea848f9888a6060c0a8947a2a7cd1eccfcfc7c3R1-R153) [[2]](diffhunk://#diff-41c6ab7ceba15681374fe068974260dc45d70c09b57a3f699b4d9f571fa58265L3-R3) [[3]](diffhunk://#diff-41c6ab7ceba15681374fe068974260dc45d70c09b57a3f699b4d9f571fa58265L16-R16) [[4]](diffhunk://#diff-41c6ab7ceba15681374fe068974260dc45d70c09b57a3f699b4d9f571fa58265L29-R29) [[5]](diffhunk://#diff-41c6ab7ceba15681374fe068974260dc45d70c09b57a3f699b4d9f571fa58265L83-R83) [[6]](diffhunk://#diff-41c6ab7ceba15681374fe068974260dc45d70c09b57a3f699b4d9f571fa58265L92-R92) [[7]](diffhunk://#diff-41c6ab7ceba15681374fe068974260dc45d70c09b57a3f699b4d9f571fa58265L158-R158) [[8]](diffhunk://#diff-41c6ab7ceba15681374fe068974260dc45d70c09b57a3f699b4d9f571fa58265L171-R171) [[9]](diffhunk://#diff-5b541f27b269918273764c315481cf0b371d73bdc8e058679946f23c656a9378L28-L43) [[10]](diffhunk://#diff-5b541f27b269918273764c315481cf0b371d73bdc8e058679946f23c656a9378L288-L303) [[11]](diffhunk://#diff-5b541f27b269918273764c315481cf0b371d73bdc8e058679946f23c656a9378L427-L437) [[12]](diffhunk://#diff-5b541f27b269918273764c315481cf0b371d73bdc8e058679946f23c656a9378L485-L489) [[13]](diffhunk://#diff-5b541f27b269918273764c315481cf0b371d73bdc8e058679946f23c656a9378L668-R637) [[14]](diffhunk://#diff-5b541f27b269918273764c315481cf0b371d73bdc8e058679946f23c656a9378L1127-L1137) [[15]](diffhunk://#diff-5b541f27b269918273764c315481cf0b371d73bdc8e058679946f23c656a9378L1453-L1462)

**2. Refactoring of `WndBase` and Control Hierarchy**
- Updated `WndBase` to inherit from `FrameworkElement` instead of `ObservableObject`, and removed its own data context and parent property, delegating those responsibilities to the new base class. (`sw/inc/WndBase.h`) [[1]](diffhunk://#diff-6f4b6c3f91b40bf12016da6157a4dc147178b33f6da546397d7b414132123ee0R8-L12) [[2]](diffhunk://#diff-6f4b6c3f91b40bf12016da6157a4dc147178b33f6da546397d7b414132123ee0L33-R33) [[3]](diffhunk://#diff-6f4b6c3f91b40bf12016da6157a4dc147178b33f6da546397d7b414132123ee0L180-L184) [[4]](diffhunk://#diff-6f4b6c3f91b40bf12016da6157a4dc147178b33f6da546397d7b414132123ee0L222-L226)
- Implemented `FrameworkElement` interface methods (`GetParent`, `GetChildCount`, `GetChildAt`) in `WndBase`. (`sw/inc/WndBase.h`)

**3. UIElement Simplification and API Adjustments**
- Removed data binding and data context management from `UIElement`. Now, `UIElement` only manages layout and visual tree responsibilities. (`sw/inc/UIElement.h`) [[1]](diffhunk://#diff-5b541f27b269918273764c315481cf0b371d73bdc8e058679946f23c656a9378L28-L43) [[2]](diffhunk://#diff-5b541f27b269918273764c315481cf0b371d73bdc8e058679946f23c656a9378L288-L303) [[3]](diffhunk://#diff-5b541f27b269918273764c315481cf0b371d73bdc8e058679946f23c656a9378L427-L437) [[4]](diffhunk://#diff-5b541f27b269918273764c315481cf0b371d73bdc8e058679946f23c656a9378L485-L489) [[5]](diffhunk://#diff-5b541f27b269918273764c315481cf0b371d73bdc8e058679946f23c656a9378L668-R637) [[6]](diffhunk://#diff-5b541f27b269918273764c315481cf0b371d73bdc8e058679946f23c656a9378L718-R665) [[7]](diffhunk://#diff-5b541f27b269918273764c315481cf0b371d73bdc8e058679946f23c656a9378L747-R688) [[8]](diffhunk://#diff-5b541f27b269918273764c315481cf0b371d73bdc8e058679946f23c656a9378L1127-L1137) [[9]](diffhunk://#diff-5b541f27b269918273764c315481cf0b371d73bdc8e058679946f23c656a9378L1453-L1462)

**4. Consistency and API Improvements**
- Made several methods in `ILayout`, `LayoutHost`, and `UIElement` const-correct and added documentation for exceptions thrown on out-of-range indices. (`sw/inc/ILayout.h`, `sw/inc/LayoutHost.h`, `sw/inc/UIElement.h`) [[1]](diffhunk://#diff-943f11169b48bd5d88f5a5e6d66713b77e68dfebbdeb09499a8d615cedf58a25R33-R35) [[2]](diffhunk://#diff-277123882de34eb1cd95e673c3228087a2962f732359594ca16572d474b82e86L34-R45) [[3]](diffhunk://#diff-5b541f27b269918273764c315481cf0b371d73bdc8e058679946f23c656a9378L718-R665)
- Updated includes in various files to reflect the new dependency on `FrameworkElement`. (`sw/inc/SimpleWindow.h`, `sw/inc/WndBase.h`) [[1]](diffhunk://#diff-23bd9e004ec24a5f582a0c62abe2642cdbc698a02becb578bd729cffd6d1259bR39) [[2]](diffhunk://#diff-6f4b6c3f91b40bf12016da6157a4dc147178b33f6da546397d7b414132123ee0R8-L12)

**5. Minor Fixes**
- Fixed a bug in `Control.cpp` where the global `::GetParent` should be used instead of a possibly shadowed `GetParent` function. (`sw/src/Control.cpp`) [[1]](diffhunk://#diff-3d8d71021a9ffd16cda244506075358ad431ec38cc5a99ce15233de7a6cb8d02L17-R17) [[2]](diffhunk://#diff-3d8d71021a9ffd16cda244506075358ad431ec38cc5a99ce15233de7a6cb8d02L48-R48)