### PR TITLE
Fix/layout visible children

### DIFF
--- a/sw/src/UIElement.cpp
+++ b/sw/src/UIElement.cpp
@@ -4,6 +4,7 @@
 #include "Utils.h"
 #include "WndMsg.h"
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <deque>
 
@@ -1562,6 +1563,12 @@ void sw::UIElement::_UpdateLayoutVisibleChildren()
 
 bool sw::UIElement::_AddToLayoutVisibleChildren(UIElement *element)
 {
+    // 调用方需保证element未在_layoutVisibleChildren中，否则
+    // 后续_RemoveFromLayoutVisibleChildren只会移除首个匹配项造成静默泄漏
+    assert(std::find(this->_layoutVisibleChildren.begin(),
+                     this->_layoutVisibleChildren.end(), element) ==
+           this->_layoutVisibleChildren.end());
+
     if (element->_collapseWhenHide && !element->Visible)
         return false;
     else {

--- a/sw/src/UIElement.cpp
+++ b/sw/src/UIElement.cpp
@@ -455,6 +455,10 @@ void sw::UIElement::ClearChildren()
 
     this->_layoutUpdateCondition |= sw::LayoutUpdateCondition::Supressed;
 
+    // 提前清空_layoutVisibleChildren，避免循环中OnRemovedChild及其触发的属性变更
+    // 回调观察到已从_children移除却仍残留在_layoutVisibleChildren中的陈旧指针
+    this->_layoutVisibleChildren.clear();
+
     while (!this->_children.empty()) {
         UIElement *item = this->_children.back();
         item->WndBase::SetParent(nullptr);
@@ -463,7 +467,6 @@ void sw::UIElement::ClearChildren()
     }
 
     this->_layoutUpdateCondition &= ~sw::LayoutUpdateCondition::Supressed;
-    this->_UpdateLayoutVisibleChildren();
 
     if (this->IsLayoutUpdateConditionSet(sw::LayoutUpdateCondition::ChildRemoved)) {
         this->InvalidateMeasure();

--- a/sw/src/UIElement.cpp
+++ b/sw/src/UIElement.cpp
@@ -403,14 +403,21 @@ bool sw::UIElement::RemoveChildAt(int index)
         return false;
     }
 
-    std::vector<UIElement *>::iterator it =
-        this->_children.begin() + index;
+    UIElement *element = this->_children[index];
 
-    if (!(*it)->WndBase::SetParent(nullptr)) {
+    if (!element->WndBase::SetParent(nullptr)) {
         return false;
     }
 
-    UIElement *element = *it;
+    // SetParent会同步派发WM_PreSetParent并最终回调虚函数ParentChanged
+    // 与OnCurrentDataContextChanged，用户重写可能重入修改_children，
+    // 因此必须重新查找element位置而非沿用之前的索引或迭代器
+    auto it = std::find(this->_children.begin(), this->_children.end(), element);
+
+    if (it == this->_children.end()) {
+        return true; // 已被嵌套调用移除并触发了OnRemovedChild
+    }
+
     this->_children.erase(it);
     this->_RemoveFromLayoutVisibleChildren(element);
 
@@ -424,15 +431,21 @@ bool sw::UIElement::RemoveChild(UIElement *element)
         return false;
     }
 
-    std::vector<UIElement *>::iterator it =
-        std::find(this->_children.begin(), this->_children.end(), element);
-
-    if (it == this->_children.end()) {
+    if (std::find(this->_children.begin(), this->_children.end(), element) == this->_children.end()) {
         return false;
     }
 
     if (!element->WndBase::SetParent(nullptr)) {
         return false;
+    }
+
+    // SetParent会同步派发WM_PreSetParent并最终回调虚函数ParentChanged
+    // 与OnCurrentDataContextChanged，用户重写可能重入修改_children，
+    // 因此必须重新查找element位置以避免使用已失效的迭代器
+    auto it = std::find(this->_children.begin(), this->_children.end(), element);
+
+    if (it == this->_children.end()) {
+        return true; // 已被嵌套调用移除并触发了OnRemovedChild
     }
 
     this->_children.erase(it);

--- a/sw/src/UIElement.cpp
+++ b/sw/src/UIElement.cpp
@@ -1228,6 +1228,9 @@ bool sw::UIElement::SetParent(WndBase *parent)
                 oldParentElement->_RemoveFromLayoutVisibleChildren(this);
                 // 通知父元素改变以触发属性变更通知以及数据上下文变更
                 this->ParentChanged(nullptr);
+                // 与正常RemoveChild路径保持一致，发出ChildCount变更通知
+                // 并在ChildRemoved条件下让父元素布局失效
+                oldParentElement->OnRemovedChild(*this);
             }
             return true;
         }


### PR DESCRIPTION
This pull request improves the robustness and correctness of child element management in the `UIElement` class, particularly around removing children and updating layout-visible children. The changes address potential issues caused by user-overridden callbacks that may modify the children list during removal operations, and ensure that layout and notification logic remains consistent and safe.

Key improvements include:

**Robustness in Child Removal:**

* In both `RemoveChildAt` and `RemoveChild`, after calling `SetParent(nullptr)`, the code now re-finds the child's position in `_children` before erasing it, to handle cases where user callbacks might have already removed the child. If the child is already removed, the function returns early. This prevents use of invalid iterators and ensures correct behavior during nested or reentrant removals. [[1]](diffhunk://#diff-13db186e9dedb13d4d2bffd3e1385bb5f85f49e4a7efecb7010fe3a2824657c8L406-R421) [[2]](diffhunk://#diff-13db186e9dedb13d4d2bffd3e1385bb5f85f49e4a7efecb7010fe3a2824657c8L427-R451)

* In `ClearChildren`, `_layoutVisibleChildren` is now cleared before removing children, preventing callbacks from observing stale pointers that have been removed from `_children` but not yet from `_layoutVisibleChildren`.

**Consistency and Notification Improvements:**

* In `SetParent`, after removing the child from the old parent, the code now also calls `OnRemovedChild` to ensure that child count change notifications and layout invalidation are consistent with the normal removal path.

**Safety and Code Quality:**

* An `assert` was added in `_AddToLayoutVisibleChildren` to ensure that the element is not already present in `_layoutVisibleChildren`, preventing silent leaks due to duplicate entries.

* The unnecessary call to `_UpdateLayoutVisibleChildren` at the end of `ClearChildren` was removed, as the visible children list is now cleared earlier.

**Other:**

* Added `#include <cassert>` to support the new assertion.