### PR TITLE
Refactor window class registration and control initialization

### DIFF
--- a/sw/inc/WndBase.h
+++ b/sw/inc/WndBase.h
@@ -33,6 +33,15 @@ namespace sw
         // HwndWrapper不使用InitWindow或InitControl初始化句柄，向其暴露底层细节以便实现相关功能
         friend class HwndWrapper;
 
+        /**
+         * @brief 当前线程中等待CBT钩子绑定HWND的WndBase实例
+         *
+         * Init* / ResetHandle 在调用 CreateWindowExW 之前把待绑定的实例
+         * 写入此变量，CBT 钩子在 HCBT_CREATEWND 时取出并将 HWND 与实例
+         * 关联，之后立即清空。
+         */
+        static thread_local WndBase *_pendingInit;
+
     private:
         /**
          * @brief 用于判断给定指针是否为指向WndBase的指针

--- a/sw/inc/WndBase.h
+++ b/sw/inc/WndBase.h
@@ -251,13 +251,15 @@ namespace sw
     protected:
         /**
          * @brief 初始化为窗口，该函数会调用CreateWindowExW
+         * @return 若函数成功则返回true，否则返回false
          */
-        void InitWindow(LPCWSTR lpWindowName, DWORD dwStyle, DWORD dwExStyle);
+        bool InitWindow(LPCWSTR lpWindowName, DWORD dwStyle, DWORD dwExStyle);
 
         /**
          * @brief 初始化为控件，该函数会调用CreateWindowExW
+         * @return 若函数成功则返回true，否则返回false
          */
-        void InitControl(LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle, DWORD dwExStyle, LPVOID lpParam = NULL);
+        bool InitControl(LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle, DWORD dwExStyle, LPVOID lpParam = NULL);
 
         /**
          * @brief 调用默认的WndProc，对于窗口则调用DefWindowProcW，控件则调用_controlOldWndProc
@@ -884,6 +886,11 @@ namespace sw
          * @brief 窗口过程函数，调用对象的WndProc
          */
         static LRESULT CALLBACK _WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+
+        /**
+         * @brief CBT钩子过程，在WM_NCCREATE之前完成HWND绑定与（控件场景下的）WndProc子类化
+         */
+        static LRESULT CALLBACK _CbtProc(int code, WPARAM wParam, LPARAM lParam);
 
         /**
          * @brief 获取控件创建时所在的容器

--- a/sw/inc/WndBase.h
+++ b/sw/inc/WndBase.h
@@ -42,6 +42,15 @@ namespace sw
          */
         static thread_local WndBase *_pendingInit;
 
+        /**
+         * @brief 当前线程中待自卸的CBT钩子句柄
+         *
+         * 与 _pendingInit 配对：调用方装钩子后写入，CBT 回调完成绑定时一并
+         * 取出并立即调用 UnhookWindowsHookEx 把自己摘掉，避免嵌套创建时
+         * 调用栈上累积多个钩子。
+         */
+        static thread_local HHOOK _pendingHook;
+
     private:
         /**
          * @brief 用于判断给定指针是否为指向WndBase的指针

--- a/sw/src/Control.cpp
+++ b/sw/src/Control.cpp
@@ -37,6 +37,10 @@ bool sw::Control::ResetHandle(DWORD style, DWORD exStyle, LPVOID lpParam)
         return false;
     }
 
+    if (_hwnd == NULL || _isDestroyed) {
+        return false;
+    }
+
     RECT rect = Rect;
     auto text = GetInternalText().c_str();
 
@@ -49,7 +53,17 @@ bool sw::Control::ResetHandle(DWORD style, DWORD exStyle, LPVOID lpParam)
     HMENU id = reinterpret_cast<HMENU>(
         static_cast<uintptr_t>(GetDlgCtrlID(oldHwnd)));
 
-    HWND newHwnd = CreateWindowExW(
+    // 用 CBT 钩子让新 HWND 在 WM_NCCREATE 之前完成绑定与子类化，
+    // 流程与 WndBase::InitControl 完全一致。
+    WndBase::_pendingInit = this;
+    HHOOK hHook           = SetWindowsHookExW(WH_CBT, WndBase::_CbtProc, NULL, GetCurrentThreadId());
+
+    if (hHook == NULL) {
+        WndBase::_pendingInit = nullptr;
+        return false;
+    }
+
+    CreateWindowExW(
         exStyle,   // Optional window styles
         className, // Window class
         text,      // Window text
@@ -64,13 +78,20 @@ bool sw::Control::ResetHandle(DWORD style, DWORD exStyle, LPVOID lpParam)
         lpParam        // Additional application data
     );
 
-    LONG_PTR wndproc =
-        SetWindowLongPtrW(oldHwnd, GWLP_WNDPROC, GetWindowLongPtrW(newHwnd, GWLP_WNDPROC));
+    UnhookWindowsHookEx(hHook);
+    WndBase::_pendingInit = nullptr;
 
-    WndBase::_SetWndBase(newHwnd, *this);
-    SetWindowLongPtrW(newHwnd, GWLP_WNDPROC, wndproc);
+    // CBT 钩子触发时已把 _hwnd 切换到新句柄；CreateWindowExW 失败时钩子不会
+    // 触发，_hwnd 仍为 oldHwnd，可据此判断是否成功。
+    if (_hwnd == oldHwnd) {
+        return false;
+    }
 
-    _hwnd = newHwnd;
+    // CBT 钩子已经把 _hwnd 切到新句柄，并刷新了 _originalWndProc（旧窗口和新窗口
+    // 同类，原始 WndProc 一致）。旧 HWND 仍指向 _WndProc 与本对象的 prop，必须把
+    // WndProc 还原为原始类 WndProc 后再销毁，让销毁路径走原生清理而不再回到框架。
+    SetWindowLongPtrW(oldHwnd, GWLP_WNDPROC,
+                      reinterpret_cast<LONG_PTR>(_originalWndProc));
     DestroyWindow(oldHwnd);
 
     SendMessageW(WM_SETFONT, (WPARAM)GetFontHandle(), TRUE);

--- a/sw/src/Control.cpp
+++ b/sw/src/Control.cpp
@@ -56,9 +56,9 @@ bool sw::Control::ResetHandle(DWORD style, DWORD exStyle, LPVOID lpParam)
     // 用 CBT 钩子让新 HWND 在 WM_NCCREATE 之前完成绑定与子类化，
     // 流程与 WndBase::InitControl 完全一致。
     WndBase::_pendingInit = this;
-    HHOOK hHook           = SetWindowsHookExW(WH_CBT, WndBase::_CbtProc, NULL, GetCurrentThreadId());
+    WndBase::_pendingHook = SetWindowsHookExW(WH_CBT, WndBase::_CbtProc, NULL, GetCurrentThreadId());
 
-    if (hHook == NULL) {
+    if (WndBase::_pendingHook == NULL) {
         WndBase::_pendingInit = nullptr;
         return false;
     }
@@ -78,8 +78,12 @@ bool sw::Control::ResetHandle(DWORD style, DWORD exStyle, LPVOID lpParam)
         lpParam        // Additional application data
     );
 
-    UnhookWindowsHookEx(hHook);
-    WndBase::_pendingInit = nullptr;
+    // 正常路径下 _CbtProc 已在 HCBT_CREATEWND 时自卸并清空。异常路径下兜底。
+    if (WndBase::_pendingHook != NULL) {
+        UnhookWindowsHookEx(WndBase::_pendingHook);
+        WndBase::_pendingHook = NULL;
+        WndBase::_pendingInit = nullptr;
+    }
 
     // CBT 钩子触发时已把 _hwnd 切换到新句柄；CreateWindowExW 失败时钩子不会
     // 触发，_hwnd 仍为 oldHwnd，可据此判断是否成功。

--- a/sw/src/Control.cpp
+++ b/sw/src/Control.cpp
@@ -33,11 +33,11 @@ bool sw::Control::ResetHandle(LPVOID lpParam)
 
 bool sw::Control::ResetHandle(DWORD style, DWORD exStyle, LPVOID lpParam)
 {
-    if (!CheckAccess()) {
+    if (_hwnd == NULL || _isDestroyed) {
         return false;
     }
 
-    if (_hwnd == NULL || _isDestroyed) {
+    if (!CheckAccess()) {
         return false;
     }
 

--- a/sw/src/WndBase.cpp
+++ b/sw/src/WndBase.cpp
@@ -31,16 +31,6 @@ namespace
      */
     std::atomic<int> _controlIdCounter{1073741827};
 
-    /**
-     * @brief 当前线程中等待CBT钩子绑定HWND的WndBase实例
-     *
-     * InitWindow / InitControl 在调用 CreateWindowExW 之前把待绑定的实例
-     * 写入此变量，CBT 钩子在 HCBT_CREATEWND 时取出并将 HWND 与实例关联，
-     * 之后立即清空。clear 后再触发的 HCBT_CREATEWND（例如 WM_CREATE 期间
-     * 嵌套创建的窗口、外部钩子链上其他人创建的窗口）会被忽略。
-     */
-    thread_local sw::WndBase *_pendingInit = nullptr;
-
     // ============================================================
     // 属性ID
     // ============================================================
@@ -65,6 +55,9 @@ namespace
     const sw::FieldId _PropId_AcceptFiles  = sw::Reflection::GetFieldId(&sw::WndBase::AcceptFiles);
     const sw::FieldId _PropId_IsGroupStart = sw::Reflection::GetFieldId(&sw::WndBase::IsGroupStart);
 }
+
+// thread_local 静态成员定义，声明见 WndBase.h
+thread_local sw::WndBase *sw::WndBase::_pendingInit = nullptr;
 
 sw::WndBase::WndBase()
     : _check(_WndBaseMagicNumber),

--- a/sw/src/WndBase.cpp
+++ b/sw/src/WndBase.cpp
@@ -358,6 +358,8 @@ bool sw::WndBase::InitWindow(LPCWSTR lpWindowName, DWORD dwStyle, DWORD dwExStyl
         return RegisterClassExW(&wc);
     }();
 
+    (void)wndClsAtom; // 消除未使用变量警告
+
     if (this->_hwnd != NULL) {
         return true;
     }

--- a/sw/src/WndBase.cpp
+++ b/sw/src/WndBase.cpp
@@ -340,20 +340,18 @@ sw::WndBase &sw::WndBase::GetChildAt(int index) const
 
 void sw::WndBase::InitWindow(LPCWSTR lpWindowName, DWORD dwStyle, DWORD dwExStyle)
 {
-    static thread_local ATOM wndClsAtom = 0;
-
-    if (this->_hwnd != NULL) {
-        return;
-    }
-
-    if (wndClsAtom == 0) {
+    static ATOM wndClsAtom = []() -> ATOM {
         WNDCLASSEXW wc{};
         wc.cbSize        = sizeof(wc);
         wc.hInstance     = App::Instance;
         wc.lpfnWndProc   = WndBase::_WndProc;
         wc.lpszClassName = _WindowClassName;
         wc.hCursor       = CursorHelper::GetCursorHandle(StandardCursor::Arrow);
-        wndClsAtom       = RegisterClassExW(&wc);
+        return RegisterClassExW(&wc);
+    }();
+
+    if (this->_hwnd != NULL) {
+        return;
     }
 
     if (lpWindowName) {

--- a/sw/src/WndBase.cpp
+++ b/sw/src/WndBase.cpp
@@ -56,8 +56,11 @@ namespace
     const sw::FieldId _PropId_IsGroupStart = sw::Reflection::GetFieldId(&sw::WndBase::IsGroupStart);
 }
 
-// thread_local 静态成员定义，声明见 WndBase.h
+// 等待 CBT 钩子绑定的 WndBase 实例（声明见 WndBase.h）
 thread_local sw::WndBase *sw::WndBase::_pendingInit = nullptr;
+
+// 与 _pendingInit 配对的钩子句柄，回调里完成绑定后自卸（声明见 WndBase.h）
+thread_local HHOOK sw::WndBase::_pendingHook = NULL;
 
 sw::WndBase::WndBase()
     : _check(_WndBaseMagicNumber),
@@ -371,9 +374,9 @@ bool sw::WndBase::InitWindow(LPCWSTR lpWindowName, DWORD dwStyle, DWORD dwExStyl
     this->_isControl = false;
 
     _pendingInit = this;
-    HHOOK hHook  = SetWindowsHookExW(WH_CBT, WndBase::_CbtProc, NULL, GetCurrentThreadId());
+    _pendingHook = SetWindowsHookExW(WH_CBT, WndBase::_CbtProc, NULL, GetCurrentThreadId());
 
-    if (hHook == NULL) {
+    if (_pendingHook == NULL) {
         _pendingInit = nullptr;
         return false;
     }
@@ -393,8 +396,13 @@ bool sw::WndBase::InitWindow(LPCWSTR lpWindowName, DWORD dwStyle, DWORD dwExStyl
         NULL           // Additional application data
     );
 
-    UnhookWindowsHookEx(hHook);
-    _pendingInit = nullptr;
+    // 正常路径下 _CbtProc 已在 HCBT_CREATEWND 时自卸并清空 _pendingHook / _pendingInit。
+    // 异常路径（CreateWindowExW 在 HCBT 触发前失败）下需在此兜底。
+    if (_pendingHook != NULL) {
+        UnhookWindowsHookEx(_pendingHook);
+        _pendingHook = NULL;
+        _pendingInit = nullptr;
+    }
 
     if (this->_hwnd == NULL) {
         return false;
@@ -419,8 +427,8 @@ bool sw::WndBase::InitControl(LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD d
     this->_isControl = true;
 
     // 注意：_GetControlInitContainer() 首次调用会嵌套进入 InitWindow，
-    // 必须在装 CBT 钩子之前完成，否则 _pendingInit 会被嵌套调用覆盖，
-    // 导致本控件创建时钩子无法绑定。
+    // 必须在装 CBT 钩子之前完成，否则嵌套调用会覆盖 _pendingInit / _pendingHook，
+    // 不仅本控件创建时钩子无法绑定，外层钩子句柄也会丢失导致兜底拆除失效。
     WndBase *container =
         WndBase::_GetControlInitContainer();
 
@@ -428,9 +436,9 @@ bool sw::WndBase::InitControl(LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD d
         static_cast<uintptr_t>(WndBase::_NextControlId()));
 
     _pendingInit = this;
-    HHOOK hHook  = SetWindowsHookExW(WH_CBT, WndBase::_CbtProc, NULL, GetCurrentThreadId());
+    _pendingHook = SetWindowsHookExW(WH_CBT, WndBase::_CbtProc, NULL, GetCurrentThreadId());
 
-    if (hHook == NULL) {
+    if (_pendingHook == NULL) {
         _pendingInit = nullptr;
         return false;
     }
@@ -447,8 +455,13 @@ bool sw::WndBase::InitControl(LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD d
         lpParam              // Additional application data
     );
 
-    UnhookWindowsHookEx(hHook);
-    _pendingInit = nullptr;
+    // 正常路径下 _CbtProc 已在 HCBT_CREATEWND 时自卸并清空 _pendingHook / _pendingInit。
+    // 异常路径（CreateWindowExW 在 HCBT 触发前失败）下需在此兜底。
+    if (_pendingHook != NULL) {
+        UnhookWindowsHookEx(_pendingHook);
+        _pendingHook = NULL;
+        _pendingInit = nullptr;
+    }
 
     if (this->_hwnd == NULL) {
         return false;
@@ -1367,9 +1380,11 @@ LRESULT CALLBACK sw::WndBase::_CbtProc(int code, WPARAM wParam, LPARAM lParam)
     {
         HWND hwnd   = reinterpret_cast<HWND>(wParam);
         auto *pThis = _pendingInit;
+        HHOOK hHook = _pendingHook;
 
-        // 立即清空，使后续（嵌套创建、外部创建）的窗口不再被绑定
+        // 立即清空，使嵌套创建、helper 窗口等后续 HCBT_CREATEWND 不再走绑定路径
         _pendingInit = nullptr;
+        _pendingHook = NULL;
 
         pThis->_hwnd = hwnd;
         WndBase::_SetWndBase(hwnd, *pThis);
@@ -1379,6 +1394,11 @@ LRESULT CALLBACK sw::WndBase::_CbtProc(int code, WPARAM wParam, LPARAM lParam)
         if (pThis->_isControl) {
             pThis->_originalWndProc = reinterpret_cast<WNDPROC>(SetWindowLongPtrW(
                 hwnd, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(WndBase::_WndProc)));
+        }
+
+        // 自卸：本钩子使命完成。链上的其他钩子（如外层 Init* 的）不受影响。
+        if (hHook != NULL) {
+            UnhookWindowsHookEx(hHook);
         }
     }
     return CallNextHookEx(NULL, code, wParam, lParam);

--- a/sw/src/WndBase.cpp
+++ b/sw/src/WndBase.cpp
@@ -7,6 +7,10 @@
 
 namespace
 {
+    // ============================================================
+    // 内部常量和变量
+    // ============================================================
+
     /**
      * @brief _check字段的值，用于判断给定指针是否为指向WndBase的指针
      */
@@ -28,8 +32,19 @@ namespace
     std::atomic<int> _controlIdCounter{1073741827};
 
     /**
-     * @brief 属性ID
+     * @brief 当前线程中等待CBT钩子绑定HWND的WndBase实例
+     *
+     * InitWindow / InitControl 在调用 CreateWindowExW 之前把待绑定的实例
+     * 写入此变量，CBT 钩子在 HCBT_CREATEWND 时取出并将 HWND 与实例关联，
+     * 之后立即清空。clear 后再触发的 HCBT_CREATEWND（例如 WM_CREATE 期间
+     * 嵌套创建的窗口、外部钩子链上其他人创建的窗口）会被忽略。
      */
+    thread_local sw::WndBase *_pendingInit = nullptr;
+
+    // ============================================================
+    // 属性ID
+    // ============================================================
+
     const sw::FieldId _PropId_Font         = sw::Reflection::GetFieldId(&sw::WndBase::Font);
     const sw::FieldId _PropId_FontName     = sw::Reflection::GetFieldId(&sw::WndBase::FontName);
     const sw::FieldId _PropId_FontSize     = sw::Reflection::GetFieldId(&sw::WndBase::FontSize);
@@ -338,7 +353,7 @@ sw::WndBase &sw::WndBase::GetChildAt(int index) const
     throw std::out_of_range("WndBase does not maintain child elements.");
 }
 
-void sw::WndBase::InitWindow(LPCWSTR lpWindowName, DWORD dwStyle, DWORD dwExStyle)
+bool sw::WndBase::InitWindow(LPCWSTR lpWindowName, DWORD dwStyle, DWORD dwExStyle)
 {
     static ATOM wndClsAtom = []() -> ATOM {
         WNDCLASSEXW wc{};
@@ -351,14 +366,24 @@ void sw::WndBase::InitWindow(LPCWSTR lpWindowName, DWORD dwStyle, DWORD dwExStyl
     }();
 
     if (this->_hwnd != NULL) {
-        return;
+        return true;
     }
 
     if (lpWindowName) {
         this->_text = lpWindowName;
     }
 
-    this->_hwnd = CreateWindowExW(
+    this->_isControl = false;
+
+    _pendingInit = this;
+    HHOOK hHook  = SetWindowsHookExW(WH_CBT, WndBase::_CbtProc, NULL, GetCurrentThreadId());
+
+    if (hHook == NULL) {
+        _pendingInit = nullptr;
+        return false;
+    }
+
+    CreateWindowExW(
         dwExStyle,           // Optional window styles
         _WindowClassName,    // Window class
         this->_text.c_str(), // Window text
@@ -370,33 +395,52 @@ void sw::WndBase::InitWindow(LPCWSTR lpWindowName, DWORD dwStyle, DWORD dwExStyl
         NULL,          // Parent window
         NULL,          // Menu
         App::Instance, // Instance handle
-        this           // Additional application data
+        NULL           // Additional application data
     );
 
-    WndBase::_SetWndBase(this->_hwnd, *this);
+    UnhookWindowsHookEx(hHook);
+    _pendingInit = nullptr;
 
-    this->UpdateInternalRect();
-    this->HandleInitialized(this->_hwnd);
-    this->UpdateFont();
+    if (this->_hwnd == NULL) {
+        return false;
+    } else {
+        this->UpdateInternalRect();
+        this->HandleInitialized(this->_hwnd);
+        this->UpdateFont();
+        return true;
+    }
 }
 
-void sw::WndBase::InitControl(LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle, DWORD dwExStyle, LPVOID lpParam)
+bool sw::WndBase::InitControl(LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle, DWORD dwExStyle, LPVOID lpParam)
 {
     if (this->_hwnd != NULL) {
-        return;
+        return true;
     }
 
     if (lpWindowName) {
         this->_text = lpWindowName;
     }
 
+    this->_isControl = true;
+
+    // 注意：_GetControlInitContainer() 首次调用会嵌套进入 InitWindow，
+    // 必须在装 CBT 钩子之前完成，否则 _pendingInit 会被嵌套调用覆盖，
+    // 导致本控件创建时钩子无法绑定。
     WndBase *container =
         WndBase::_GetControlInitContainer();
 
     HMENU id = reinterpret_cast<HMENU>(
         static_cast<uintptr_t>(WndBase::_NextControlId()));
 
-    this->_hwnd = CreateWindowExW(
+    _pendingInit = this;
+    HHOOK hHook  = SetWindowsHookExW(WH_CBT, WndBase::_CbtProc, NULL, GetCurrentThreadId());
+
+    if (hHook == NULL) {
+        _pendingInit = nullptr;
+        return false;
+    }
+
+    CreateWindowExW(
         dwExStyle,           // Optional window styles
         lpClassName,         // Window class
         this->_text.c_str(), // Window text
@@ -408,14 +452,16 @@ void sw::WndBase::InitControl(LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD d
         lpParam              // Additional application data
     );
 
-    this->_isControl = true;
-    WndBase::_SetWndBase(this->_hwnd, *this);
+    UnhookWindowsHookEx(hHook);
+    _pendingInit = nullptr;
 
-    this->_originalWndProc = reinterpret_cast<WNDPROC>(SetWindowLongPtrW(
-        this->_hwnd, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(WndBase::_WndProc)));
-
-    this->HandleInitialized(this->_hwnd);
-    this->UpdateFont();
+    if (this->_hwnd == NULL) {
+        return false;
+    } else {
+        this->HandleInitialized(this->_hwnd);
+        this->UpdateFont();
+        return true;
+    }
 }
 
 LRESULT sw::WndBase::DefaultWndProc(const ProcMsg &msg)
@@ -1310,24 +1356,37 @@ bool sw::WndBase::IsPtrValid(const WndBase *ptr) noexcept
 
 LRESULT sw::WndBase::_WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-    WndBase *pWnd = nullptr;
+    auto *pThis = WndBase::GetWndBase(hwnd);
 
-    if (hwnd != NULL) {
-        pWnd = WndBase::GetWndBase(hwnd);
-    }
-
-    if (pWnd == nullptr && (uMsg == WM_NCCREATE || uMsg == WM_CREATE)) {
-        auto temp = reinterpret_cast<WndBase *>(
-            reinterpret_cast<LPCREATESTRUCTW>(lParam)->lpCreateParams);
-        if (IsPtrValid(temp)) pWnd = temp;
-    }
-
-    if (pWnd != nullptr) {
+    if (pThis != nullptr) {
         ProcMsg msg{hwnd, uMsg, wParam, lParam};
-        return pWnd->WndProc(msg);
+        return pThis->WndProc(msg);
+    } else {
+        return DefWindowProcW(hwnd, uMsg, wParam, lParam);
     }
+}
 
-    return DefWindowProcW(hwnd, uMsg, wParam, lParam);
+LRESULT CALLBACK sw::WndBase::_CbtProc(int code, WPARAM wParam, LPARAM lParam)
+{
+    if (code == HCBT_CREATEWND && _pendingInit != nullptr) //
+    {
+        HWND hwnd   = reinterpret_cast<HWND>(wParam);
+        auto *pThis = _pendingInit;
+
+        // 立即清空，使后续（嵌套创建、外部创建）的窗口不再被绑定
+        _pendingInit = nullptr;
+
+        pThis->_hwnd = hwnd;
+        WndBase::_SetWndBase(hwnd, *pThis);
+
+        // 控件场景下需要把 WndProc 替换为 _WndProc 以拦截后续消息；
+        // 此时 WM_NCCREATE 尚未派发，替换在所有消息之前完成。
+        if (pThis->_isControl) {
+            pThis->_originalWndProc = reinterpret_cast<WNDPROC>(SetWindowLongPtrW(
+                hwnd, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(WndBase::_WndProc)));
+        }
+    }
+    return CallNextHookEx(NULL, code, wParam, lParam);
 }
 
 sw::WndBase *sw::WndBase::_GetControlInitContainer()
@@ -1390,8 +1449,7 @@ sw::WndBase *sw::WndBase::_GetControlInitContainer()
         }
     };
 
-    if (_guard.container == nullptr ||
-        _guard.container->_isDestroyed) {
+    if (_guard.container == nullptr || _guard.container->_isDestroyed) {
         _guard.container = std::make_unique<_ControlInitContainer>();
     }
     return _guard.container.get();


### PR DESCRIPTION
This pull request introduces a significant refactor of the window/control creation and handle-reset logic in the `WndBase` and `Control` classes, focusing on robust and thread-safe association of HWND handles with their C++ objects. The changes implement a CBT (Computer-Based Training) Windows hook to guarantee that the binding and subclassing of window procedures occur before any window messages are dispatched, addressing edge cases and potential race conditions during HWND creation, especially for controls. Additionally, the initialization methods now return success/failure, improving error handling.

Key changes include:

**Robust HWND Binding and Subclassing via CBT Hook:**

* Introduced two `thread_local` static members, `_pendingInit` and `_pendingHook`, in `WndBase` to track the instance awaiting HWND binding and its associated CBT hook within the current thread. These are used to ensure that the correct object is associated with the newly created HWND before any messages are processed. (`WndBase.h`/`WndBase.cpp`) [[1]](diffhunk://#diff-6f4b6c3f91b40bf12016da6157a4dc147178b33f6da546397d7b414132123ee0R36-R53) [[2]](diffhunk://#diff-57971b60f3f0dfce9c54fe15c6050ea59fa80d2429a25531f2253167a9d3b49aR59-R64)
* Added the `_CbtProc` static method to `WndBase`, implementing the CBT hook procedure. It binds the HWND to the `WndBase` instance and subclasses the window procedure for controls before any window messages are dispatched. The hook self-uninstalls immediately after use to avoid stacking hooks in nested scenarios. (`WndBase.h`/`WndBase.cpp`) [[1]](diffhunk://#diff-6f4b6c3f91b40bf12016da6157a4dc147178b33f6da546397d7b414132123ee0R908-R912) [[2]](diffhunk://#diff-57971b60f3f0dfce9c54fe15c6050ea59fa80d2429a25531f2253167a9d3b49aL1315-R1404)

**Initialization and Handle Management Improvements:**

* Changed the signatures of `InitWindow` and `InitControl` in `WndBase`, and `ResetHandle` in `Control`, to return `bool` indicating success or failure, and updated their implementations to use the CBT hook for HWND binding. Error handling is improved, and fallback paths ensure hooks are always cleaned up. (`WndBase.h`, `WndBase.cpp`, `Control.cpp`) [[1]](diffhunk://#diff-6f4b6c3f91b40bf12016da6157a4dc147178b33f6da546397d7b414132123ee0R272-R280) [[2]](diffhunk://#diff-3d8d71021a9ffd16cda244506075358ad431ec38cc5a99ce15233de7a6cb8d02R36-R39) [[3]](diffhunk://#diff-3d8d71021a9ffd16cda244506075358ad431ec38cc5a99ce15233de7a6cb8d02L52-R66) [[4]](diffhunk://#diff-3d8d71021a9ffd16cda244506075358ad431ec38cc5a99ce15233de7a6cb8d02L67-R98) [[5]](diffhunk://#diff-57971b60f3f0dfce9c54fe15c6050ea59fa80d2429a25531f2253167a9d3b49aL341-R384) [[6]](diffhunk://#diff-57971b60f3f0dfce9c54fe15c6050ea59fa80d2429a25531f2253167a9d3b49aL375-R446) [[7]](diffhunk://#diff-57971b60f3f0dfce9c54fe15c6050ea59fa80d2429a25531f2253167a9d3b49aL413-R472)

**Code Cleanup and Documentation:**

* Enhanced comments and documentation throughout the code to clarify the new logic, especially around the hook lifecycle and error paths. Grouped and clarified internal constants and variable declarations. (`WndBase.h`, `WndBase.cpp`) [[1]](diffhunk://#diff-57971b60f3f0dfce9c54fe15c6050ea59fa80d2429a25531f2253167a9d3b49aR10-R13) [[2]](diffhunk://#diff-57971b60f3f0dfce9c54fe15c6050ea59fa80d2429a25531f2253167a9d3b49aL30-R37)

These changes make window/control creation safer and more reliable, especially in multithreaded or nested creation scenarios, and provide clearer error reporting for initialization failures.