### PR TITLE
Dev

### DIFF
--- a/examples/10_datacontext/MyWindow.hpp
+++ b/examples/10_datacontext/MyWindow.hpp
@@ -36,7 +36,7 @@ private:
          */
 
         // 设置当前窗口的DataContext为viewModel实例
-        DataContext = &viewModel;
+        DataContext = sw::Variant::MakeRef(viewModel);
 
         // 绑定slider的Value属性到viewModel的Value属性，双向绑定
         // 添加绑定时若没有指定源对象，则自动绑定到CurrentDataContext

--- a/single_header/build.py
+++ b/single_header/build.py
@@ -129,7 +129,22 @@ sources = []
 
 # 输出文件
 outputfile = open(os.path.join(basedir, 'sw_all.cpp'), 'w', encoding='utf-8')
-outputfile.write('#include "sw_all.h"\n')
+
+# 文件头部注释和主头文件包含
+outputfile.write('''\
+/**
+ * @file    sw_all.cpp
+ * @brief   SimpleWindow单文件版本（合并实现文件）
+ * @details 本文件由 single_header/build.py 脚本根据 sw/src 目录下的全部源文件
+ *          合并生成，包含SimpleWindow框架对外公开类型与控件的全部实现代码，
+ *          需与 sw_all.h 配合使用，可作为单文件分发版本使用。
+ * @note    该文件为自动生成产物，请勿手动修改；如需变更内容，请编辑 sw/src 下
+ *          对应的源文件并重新运行 single_header/build.py 重新生成。
+ * @see     https://github.com/Mzying2001/sw
+ */
+
+#include "sw_all.h"
+''')
 
 # 输出的源文件代码
 code = ''

--- a/single_header/build.py
+++ b/single_header/build.py
@@ -15,8 +15,22 @@ headers = []
 
 # 输出文件
 outputfile = open(os.path.join(basedir, 'sw_all.h'), 'w', encoding='utf-8')
-outputfile.write('// https://github.com/Mzying2001/sw\n\n')
-outputfile.write('#pragma once\n')
+
+# 文件头部注释和防重复包含指令
+outputfile.write('''\
+/**
+ * @file    sw_all.h
+ * @brief   SimpleWindow单文件版本（合并头文件）
+ * @details 本文件由 single_header/build.py 脚本根据 sw/inc 目录下的全部头文件
+ *          按依赖关系进行拓扑排序后自动合并生成，包含SimpleWindow框架对外公开
+ *          的所有类型、控件、宏与工具函数声明，可作为单头文件分发版本使用。
+ * @note    该文件为自动生成产物，请勿手动修改；如需变更内容，请编辑 sw/inc 下
+ *          对应的源头文件并重新运行 single_header/build.py 重新生成。
+ * @see     https://github.com/Mzying2001/sw
+ */
+
+#pragma once
+''')
 
 # 添加文件到列表
 for item in sorted(os.listdir(incpath)):

--- a/sw/inc/Color.h
+++ b/sw/inc/Color.h
@@ -51,13 +51,15 @@ namespace sw
 
         /**
          * @brief 通过COLORREF构造Color结构体
+         * @note 标记为explicit以避免与隐式转换operator COLORREF()联用时
+         *       发生意外的隐式整数到Color的转换路径
          */
-        Color(COLORREF color) noexcept;
+        explicit Color(COLORREF color) noexcept;
 
         /**
-         * @brief 隐式转换COLORREF
+         * @brief 显式转换为COLORREF（与explicit Color(COLORREF)对称）
          */
-        operator COLORREF() const noexcept;
+        explicit operator COLORREF() const noexcept;
 
         /**
          * @brief 判断两个Color是否相等

--- a/sw/inc/Color.h
+++ b/sw/inc/Color.h
@@ -42,27 +42,27 @@ namespace sw
         /**
          * @brief 通过rgb构造Color结构体
          */
-        Color(uint8_t r, uint8_t g, uint8_t b);
+        Color(uint8_t r, uint8_t g, uint8_t b) noexcept;
 
         /**
          * @brief 通过KnownColors构造Color结构体
          */
-        Color(KnownColors knownColor);
+        Color(KnownColors knownColor) noexcept;
 
         /**
          * @brief 通过COLORREF构造Color结构体
          */
-        Color(COLORREF color);
+        Color(COLORREF color) noexcept;
 
         /**
          * @brief 隐式转换COLORREF
          */
-        operator COLORREF() const;
+        operator COLORREF() const noexcept;
 
         /**
          * @brief 判断两个Color是否相等
          */
-        bool Equals(const Color &other) const;
+        bool Equals(const Color &other) const noexcept;
 
         /**
          * @brief 获取描述当前对象的字符串

--- a/sw/inc/Delegate.h
+++ b/sw/inc/Delegate.h
@@ -890,7 +890,7 @@ namespace sw
          * @brief 判断当前委托是否有效
          * @return 如果委托不为空则返回true，否则返回false
          */
-        operator bool() const noexcept
+        explicit operator bool() const noexcept
         {
             return !_data.IsEmpty();
         }

--- a/sw/inc/Delegate.h
+++ b/sw/inc/Delegate.h
@@ -435,6 +435,12 @@ namespace sw
                 memset(_storage, 0, sizeof(_storage));
                 new (_storage) T(std::move(value));
             }
+            // 禁用拷贝/移动：默认实现会按字节拷贝 _storage，不会调用 T 的构造函数，
+            // 对非平凡可拷贝类型会破坏不变式。需要克隆请走 Clone()。
+            _CallableWrapperImpl(const _CallableWrapperImpl &)            = delete;
+            _CallableWrapperImpl(_CallableWrapperImpl &&)                 = delete;
+            _CallableWrapperImpl &operator=(const _CallableWrapperImpl &) = delete;
+            _CallableWrapperImpl &operator=(_CallableWrapperImpl &&)      = delete;
             virtual ~_CallableWrapperImpl()
             {
                 GetValue().~T();
@@ -508,6 +514,10 @@ namespace sw
                 : obj(&obj), func(func)
             {
             }
+            _MemberFuncWrapper(const _MemberFuncWrapper &)            = delete;
+            _MemberFuncWrapper(_MemberFuncWrapper &&)                 = delete;
+            _MemberFuncWrapper &operator=(const _MemberFuncWrapper &) = delete;
+            _MemberFuncWrapper &operator=(_MemberFuncWrapper &&)      = delete;
             TRet Invoke(Args... args) const override
             {
                 return (obj->*func)(std::forward<Args>(args)...);
@@ -544,6 +554,10 @@ namespace sw
                 : obj(&obj), func(func)
             {
             }
+            _ConstMemberFuncWrapper(const _ConstMemberFuncWrapper &)            = delete;
+            _ConstMemberFuncWrapper(_ConstMemberFuncWrapper &&)                 = delete;
+            _ConstMemberFuncWrapper &operator=(const _ConstMemberFuncWrapper &) = delete;
+            _ConstMemberFuncWrapper &operator=(_ConstMemberFuncWrapper &&)      = delete;
             TRet Invoke(Args... args) const override
             {
                 return (obj->*func)(std::forward<Args>(args)...);

--- a/sw/inc/Delegate.h
+++ b/sw/inc/Delegate.h
@@ -306,11 +306,9 @@ namespace sw
                     if (list.empty()) {
                         _Reset();
                     }
-                    // else if (list.size() == 1) {
-                    //     auto ptr = list.front()->Clone();
-                    //     _Reset(STATE_SINGLE);
-                    //     _GetSingle().reset(ptr);
-                    // }
+                    // 注：LIST 仅剩 1 元素时不降级回 SINGLE。shared_ptr 无法转移给
+                    // unique_ptr，强行 Clone 反而带来额外开销，保留 LIST 单元素状态
+                    // 在功能与性能上都可接受。
                     return true;
                 }
                 default: {

--- a/sw/inc/Delegate.h
+++ b/sw/inc/Delegate.h
@@ -226,6 +226,12 @@ namespace sw
         /**
          * @brief 添加一个可调用对象到列表中
          * @note 传入对象的生命周期将由CallableList管理
+         * @note 异常安全：
+         *       - SINGLE→LIST 升级时使用 reserve(2) 避免后续 emplace_back 触发扩容，
+         *         此时唯一的失败路径是 shared_ptr 控制块分配失败，shared_ptr 构造函数
+         *         保证抛异常时自动 delete 传入的裸指针。
+         *       - STATE_LIST 分支先把裸指针转交给本地 shared_ptr，再 emplace_back，
+         *         即使 vector 扩容失败，本地 shared_ptr 析构时也会正确释放对象。
          */
         void Add(TCallable *callable)
         {
@@ -241,6 +247,7 @@ namespace sw
                 }
                 case STATE_SINGLE: {
                     TSharedList list;
+                    list.reserve(2);
                     list.emplace_back(_GetSingle().release());
                     list.emplace_back(callable);
                     _Reset(STATE_LIST);
@@ -248,7 +255,8 @@ namespace sw
                     break;
                 }
                 case STATE_LIST: {
-                    _GetList().emplace_back(callable);
+                    std::shared_ptr<TCallable> sp(callable);
+                    _GetList().emplace_back(std::move(sp));
                     break;
                 }
             }

--- a/sw/inc/Delegate.h
+++ b/sw/inc/Delegate.h
@@ -704,13 +704,17 @@ namespace sw
 
         /**
          * @brief 添加一个可调用对象到委托中
+         * @note 当传入对象是同类型 Delegate 时：
+         *       - 内部为空：直接返回；
+         *       - 内部恰好 1 个元素：展开添加该元素的克隆（与单播添加等价）；
+         *       - 内部 ≥2 个元素：作为整体嵌套加入，不展开。
+         *       后一种"不展开"是有意为之，目的是保证 += 与 -= 的对称性：
+         *       后续 `*this -= callable` 仍可按整体匹配并撤销本次添加。
+         *       因此 `b += a; b == a` 在 a 含 ≥2 元素时为 false（Count 不同），
+         *       但 `b += a; b -= a` 后 b 与添加前等价。
          */
         void Add(const ICallable<TRet(Args...)> &callable)
         {
-            // 当添加的可调用对象与当前委托类型相同时（针对单播委托进行优化）：
-            // - 若委托内容为空，则直接返回
-            // - 若委托内容只有一个元素，则克隆该元素并添加到当前委托中
-            // - 否则，直接添加该可调用对象的克隆
             if (callable.GetType() == GetType()) {
                 auto &delegate = static_cast<const Delegate &>(callable);
                 if (delegate._data.IsEmpty()) {
@@ -773,13 +777,14 @@ namespace sw
          * @brief 移除一个可调用对象
          * @return 如果成功移除则返回true，否则返回false
          * @note 按照添加顺序从后向前查找，找到第一个匹配的可调用对象并移除
+         * @note 与 Add 逻辑严格对称——当传入对象是同类型 Delegate 时：
+         *       - 内部为空：返回 false；
+         *       - 内部恰好 1 个元素：尝试匹配并移除该元素本身；
+         *       - 内部 ≥2 个元素：按整体（嵌套 Delegate）匹配并移除，
+         *         恰好对应 Add 时"不展开整体加入"的行为。
          */
         bool Remove(const ICallable<TRet(Args...)> &callable)
         {
-            // 当移除的可调用对象与当前委托类型相同时（与Add逻辑相对应）：
-            // - 若委托内容为空，则直接返回false
-            // - 若委托内容只有一个元素，则尝试移除该元素
-            // - 否则，直接调用_Remove函数进行移除
             if (callable.GetType() == GetType()) {
                 auto &delegate = static_cast<const Delegate &>(callable);
                 if (delegate._data.IsEmpty()) {

--- a/sw/inc/Delegate.h
+++ b/sw/inc/Delegate.h
@@ -125,6 +125,9 @@ namespace sw
 
         /**
          * @brief 拷贝赋值运算
+         * @note 强异常安全：先在本地完成可能抛异常的 Clone / vector 拷贝，
+         *       全部成功后再原子地切换 *this 的状态。提交阶段（_Reset(state) 与
+         *       unique_ptr/vector 的移动赋值）均为 noexcept，不会导致中间不一致。
          */
         CallableList &operator=(const CallableList &other)
         {
@@ -132,18 +135,21 @@ namespace sw
                 return *this;
             }
 
-            _Reset(other._state);
-
             switch (other._state) {
                 case STATE_NONE: {
+                    _Reset();
                     break;
                 }
                 case STATE_SINGLE: {
-                    _GetSingle().reset(other._GetSingle()->Clone());
+                    std::unique_ptr<TCallable> cloned(other._GetSingle()->Clone());
+                    _Reset(STATE_SINGLE);
+                    _GetSingle() = std::move(cloned);
                     break;
                 }
                 case STATE_LIST: {
-                    _GetList() = other._GetList();
+                    TSharedList copied = other._GetList();
+                    _Reset(STATE_LIST);
+                    _GetList() = std::move(copied);
                     break;
                 }
             }

--- a/sw/inc/Delegate.h
+++ b/sw/inc/Delegate.h
@@ -433,12 +433,6 @@ namespace sw
                 memset(_storage, 0, sizeof(_storage));
                 new (_storage) T(std::move(value));
             }
-            // 禁用拷贝/移动：默认实现会按字节拷贝 _storage，不会调用 T 的构造函数，
-            // 对非平凡可拷贝类型会破坏不变式。需要克隆请走 Clone()。
-            _CallableWrapperImpl(const _CallableWrapperImpl &)            = delete;
-            _CallableWrapperImpl(_CallableWrapperImpl &&)                 = delete;
-            _CallableWrapperImpl &operator=(const _CallableWrapperImpl &) = delete;
-            _CallableWrapperImpl &operator=(_CallableWrapperImpl &&)      = delete;
             virtual ~_CallableWrapperImpl()
             {
                 GetValue().~T();
@@ -496,6 +490,14 @@ namespace sw
             {
                 return this == &other;
             }
+
+        public:
+            // 禁用拷贝/移动：默认实现会按字节拷贝 _storage，不会调用 T 的构造函数，
+            // 对非平凡可拷贝类型会破坏不变式。需要克隆请走 Clone()。
+            _CallableWrapperImpl(const _CallableWrapperImpl &)            = delete;
+            _CallableWrapperImpl(_CallableWrapperImpl &&)                 = delete;
+            _CallableWrapperImpl &operator=(const _CallableWrapperImpl &) = delete;
+            _CallableWrapperImpl &operator=(_CallableWrapperImpl &&)      = delete;
         };
 
         template <typename T>
@@ -512,10 +514,6 @@ namespace sw
                 : obj(&obj), func(func)
             {
             }
-            _MemberFuncWrapper(const _MemberFuncWrapper &)            = delete;
-            _MemberFuncWrapper(_MemberFuncWrapper &&)                 = delete;
-            _MemberFuncWrapper &operator=(const _MemberFuncWrapper &) = delete;
-            _MemberFuncWrapper &operator=(_MemberFuncWrapper &&)      = delete;
             TRet Invoke(Args... args) const override
             {
                 return (obj->*func)(std::forward<Args>(args)...);
@@ -539,6 +537,13 @@ namespace sw
                 const auto &otherWrapper = static_cast<const _MemberFuncWrapper &>(other);
                 return obj == otherWrapper.obj && func == otherWrapper.func;
             }
+
+        public:
+            // 禁用拷贝/移动：与 _CallableWrapperImpl 保持一致，需要克隆请走 Clone()。
+            _MemberFuncWrapper(const _MemberFuncWrapper &)            = delete;
+            _MemberFuncWrapper(_MemberFuncWrapper &&)                 = delete;
+            _MemberFuncWrapper &operator=(const _MemberFuncWrapper &) = delete;
+            _MemberFuncWrapper &operator=(_MemberFuncWrapper &&)      = delete;
         };
 
         template <typename T>
@@ -552,10 +557,6 @@ namespace sw
                 : obj(&obj), func(func)
             {
             }
-            _ConstMemberFuncWrapper(const _ConstMemberFuncWrapper &)            = delete;
-            _ConstMemberFuncWrapper(_ConstMemberFuncWrapper &&)                 = delete;
-            _ConstMemberFuncWrapper &operator=(const _ConstMemberFuncWrapper &) = delete;
-            _ConstMemberFuncWrapper &operator=(_ConstMemberFuncWrapper &&)      = delete;
             TRet Invoke(Args... args) const override
             {
                 return (obj->*func)(std::forward<Args>(args)...);
@@ -579,6 +580,13 @@ namespace sw
                 const auto &otherWrapper = static_cast<const _ConstMemberFuncWrapper &>(other);
                 return obj == otherWrapper.obj && func == otherWrapper.func;
             }
+
+        public:
+            // 禁用拷贝/移动：与 _CallableWrapperImpl 保持一致，需要克隆请走 Clone()。
+            _ConstMemberFuncWrapper(const _ConstMemberFuncWrapper &)            = delete;
+            _ConstMemberFuncWrapper(_ConstMemberFuncWrapper &&)                 = delete;
+            _ConstMemberFuncWrapper &operator=(const _ConstMemberFuncWrapper &) = delete;
+            _ConstMemberFuncWrapper &operator=(_ConstMemberFuncWrapper &&)      = delete;
         };
 
     private:

--- a/sw/inc/Delegate.h
+++ b/sw/inc/Delegate.h
@@ -10,28 +10,8 @@
 #include <typeindex>
 #include <vector>
 
-#if defined(__cpp_lib_launder) && __cpp_lib_launder >= 201606L
-#include <new>
-#endif
-
 namespace sw
 {
-    namespace _DelegateInternal
-    {
-        // C++17 起，placement-new 后通过原始字节缓冲访问对象需要 std::launder 才能
-        // 严格符合标准（避免严格别名 UB）。C++14 下 std::launder 不可用，回退为
-        // 直接 reinterpret_cast，行为在主流编译器上一致。
-        template <typename T>
-        constexpr T *_LaunderPtr(T *p) noexcept
-        {
-#if defined(__cpp_lib_launder) && __cpp_lib_launder >= 201606L
-            return std::launder(p);
-#else
-            return p;
-#endif
-        }
-    }
-
     // ICallable接口声明
     template <typename>
     struct ICallable;
@@ -352,7 +332,7 @@ namespace sw
          */
         constexpr TSinglePtr &_GetSingle() const noexcept
         {
-            return *_DelegateInternal::_LaunderPtr(reinterpret_cast<TSinglePtr *>(_data._single));
+            return *reinterpret_cast<TSinglePtr *>(_data._single);
         }
 
         /**
@@ -360,7 +340,7 @@ namespace sw
          */
         constexpr TSharedList &_GetList() const noexcept
         {
-            return *_DelegateInternal::_LaunderPtr(reinterpret_cast<TSharedList *>(_data._list));
+            return *reinterpret_cast<TSharedList *>(_data._list);
         }
 
         /**
@@ -466,7 +446,7 @@ namespace sw
             }
             T &GetValue() const noexcept
             {
-                return *_DelegateInternal::_LaunderPtr(reinterpret_cast<T *>(_storage));
+                return *reinterpret_cast<T *>(_storage);
             }
             TRet Invoke(Args... args) const override
             {

--- a/sw/inc/Delegate.h
+++ b/sw/inc/Delegate.h
@@ -978,6 +978,8 @@ namespace sw
          * @brief 调用所有存储的可调用对象，并返回它们的结果
          * @param args 函数参数
          * @return 返回一个包含所有可调用对象返回值的vector
+         * @note 多播调用时，前 N-1 次按左值传参，仅最后一次执行 std::forward，
+         *       避免对 move-only 类型或右值引用形参反复 move 同一对象。
          */
         template <typename U = TRet>
         auto InvokeAll(Args... args) const
@@ -991,10 +993,11 @@ namespace sw
                 results.emplace_back(_data[0]->Invoke(std::forward<Args>(args)...));
             } else {
                 auto list = _data;
-                results.reserve(count = list.Count());
-                for (size_t i = 0; i < count; ++i) {
-                    results.emplace_back(list[i]->Invoke(std::forward<Args>(args)...));
+                results.reserve(count);
+                for (size_t i = 0; i + 1 < count; ++i) {
+                    results.emplace_back(list[i]->Invoke(args...));
                 }
+                results.emplace_back(list[count - 1]->Invoke(std::forward<Args>(args)...));
             }
             return results;
         }
@@ -1023,6 +1026,8 @@ namespace sw
 
         /**
          * @brief 内部函数，Invoke和operator()的实现
+         * @note 多播调用时，前 N-1 次按左值传参，仅最后一次执行 std::forward，
+         *       避免对 move-only 类型或右值引用形参反复 move 同一对象。
          */
         inline TRet _InvokeImpl(Args... args) const
         {
@@ -1033,8 +1038,8 @@ namespace sw
                 return _data[0]->Invoke(std::forward<Args>(args)...);
             } else {
                 auto list = _data;
-                for (size_t i = 0; i < count - 1; ++i)
-                    list[i]->Invoke(std::forward<Args>(args)...);
+                for (size_t i = 0; i + 1 < count; ++i)
+                    list[i]->Invoke(args...);
                 return list[count - 1]->Invoke(std::forward<Args>(args)...);
             }
         }

--- a/sw/inc/Delegate.h
+++ b/sw/inc/Delegate.h
@@ -10,8 +10,28 @@
 #include <typeindex>
 #include <vector>
 
+#if defined(__cpp_lib_launder) && __cpp_lib_launder >= 201606L
+#include <new>
+#endif
+
 namespace sw
 {
+    namespace _DelegateInternal
+    {
+        // C++17 起，placement-new 后通过原始字节缓冲访问对象需要 std::launder 才能
+        // 严格符合标准（避免严格别名 UB）。C++14 下 std::launder 不可用，回退为
+        // 直接 reinterpret_cast，行为在主流编译器上一致。
+        template <typename T>
+        constexpr T *_LaunderPtr(T *p) noexcept
+        {
+#if defined(__cpp_lib_launder) && __cpp_lib_launder >= 201606L
+            return std::launder(p);
+#else
+            return p;
+#endif
+        }
+    }
+
     // ICallable接口声明
     template <typename>
     struct ICallable;
@@ -334,7 +354,7 @@ namespace sw
          */
         constexpr TSinglePtr &_GetSingle() const noexcept
         {
-            return *reinterpret_cast<TSinglePtr *>(_data._single);
+            return *_DelegateInternal::_LaunderPtr(reinterpret_cast<TSinglePtr *>(_data._single));
         }
 
         /**
@@ -342,7 +362,7 @@ namespace sw
          */
         constexpr TSharedList &_GetList() const noexcept
         {
-            return *reinterpret_cast<TSharedList *>(_data._list);
+            return *_DelegateInternal::_LaunderPtr(reinterpret_cast<TSharedList *>(_data._list));
         }
 
         /**
@@ -448,7 +468,7 @@ namespace sw
             }
             T &GetValue() const noexcept
             {
-                return *reinterpret_cast<T *>(_storage);
+                return *_DelegateInternal::_LaunderPtr(reinterpret_cast<T *>(_storage));
             }
             TRet Invoke(Args... args) const override
             {

--- a/sw/inc/FrameworkElement.h
+++ b/sw/inc/FrameworkElement.h
@@ -132,19 +132,19 @@ namespace sw
 
     public:
         /**
-         * @brief 获取父元素
+         * @brief 获取逻辑树中的父元素
          * @return 父元素指针，如果没有父元素则返回nullptr
          */
         virtual FrameworkElement *GetParent() const = 0;
 
         /**
-         * @brief 获取子元素数量
+         * @brief 获取逻辑树中的子元素数量
          * @return 子元素数量
          */
         virtual int GetChildCount() const = 0;
 
         /**
-         * @brief 获取指定索引处的子元素
+         * @brief 获取逻辑树中指定索引处的子元素
          * @param index 子元素索引
          * @throw std::out_of_range 如果索引超出范围
          */

--- a/sw/inc/FrameworkElement.h
+++ b/sw/inc/FrameworkElement.h
@@ -56,6 +56,9 @@ namespace sw
 
         /**
          * @brief 数据上下文
+         * @note 若需以引用语义持有外部对象，请使用Variant::MakeRef构造，
+         *       而非传入DynamicObject*裸指针 —— 后者会被Variant按值装箱为
+         *       BoxedObject<DynamicObject*>，导致绑定无法解析到原对象。
          */
         const Property<Variant> DataContext;
 

--- a/sw/inc/FrameworkElement.h
+++ b/sw/inc/FrameworkElement.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Binding.h"
+#include "ITag.h"
 #include "ObservableObject.h"
 #include "Variant.h"
 #include <unordered_map>
@@ -30,13 +31,19 @@ namespace sw
     /**
      * @brief 框架元素类，提供数据上下文和绑定功能
      */
-    class FrameworkElement : public ObservableObject
+    class FrameworkElement : public ObservableObject,
+                             public ITag<Variant>
     {
     private:
         /**
          * @brief 属性的绑定信息
          */
         std::unordered_map<FieldId, std::unique_ptr<BindingBase>> _bindings{};
+
+        /**
+         * @brief 用户自定义数据标签
+         */
+        Variant _tag = nullptr;
 
         /**
          * @brief 数据上下文
@@ -53,6 +60,11 @@ namespace sw
          * @brief 数据上下文改变时触发该事件
          */
         const Event<DataContextChangedEventHandler> DataContextChanged;
+
+        /**
+         * @brief 自定义数据标签，可用于存储任意用户数据
+         */
+        const Property<Variant> Tag;
 
         /**
          * @brief 数据上下文
@@ -126,6 +138,17 @@ namespace sw
         template <typename T, typename TProperty>
         bool RemoveBinding(TProperty T::*prop)
         { return RemoveBinding(Reflection::GetFieldId(prop)); }
+
+    public:
+        /**
+         * @brief 获取Tag
+         */
+        virtual Variant GetTag() const override final;
+
+        /**
+         * @brief 设置Tag
+         */
+        virtual void SetTag(const Variant &tag) override final;
 
     protected:
         /**

--- a/sw/inc/FrameworkElement.h
+++ b/sw/inc/FrameworkElement.h
@@ -2,6 +2,7 @@
 
 #include "Binding.h"
 #include "ObservableObject.h"
+#include "Variant.h"
 #include <unordered_map>
 
 namespace sw
@@ -40,7 +41,7 @@ namespace sw
         /**
          * @brief 数据上下文
          */
-        DynamicObject *_dataContext = nullptr;
+        Variant _dataContext = nullptr;
 
         /**
          * @brief 数据上下文改变事件委托
@@ -56,7 +57,7 @@ namespace sw
         /**
          * @brief 数据上下文
          */
-        const Property<DynamicObject *> DataContext;
+        const Property<Variant> DataContext;
 
         /**
          * @brief 当前元素的有效数据上下文

--- a/sw/inc/Macros.h
+++ b/sw/inc/Macros.h
@@ -6,29 +6,32 @@
 /*================================================================================*/
 
 /**
- * SW_DEFINE_*_PROPERTY系列宏：
- * 用于简化对字段的属性封装，该系列宏均支持自定义Getter和Setter函数，只需在类中定义对应的Get_{field name}和
- * Set_{field name}函数即可，生成的属性会自动调用这些函数，否则会直接访问字段本身。
+ * @file Macros.h
+ * @brief 属性定义辅助宏，用于在类中以单行声明的方式生成 sw::Property 系列成员
  *
- * - SW_DEFINE_PROPERTY(name, field)
- * - SW_DEFINE_READONLY_PROPERTY(name, field)
- * - SW_DEFINE_WRITEONLY_PROPERTY(name, field)
- * - SW_DEFINE_NOTIFY_PROPERTY(name, field)
+ * @par SW_DEFINE_*_PROPERTY 系列（基于字段）
+ * 对类内的非静态数据成员进行属性封装。若类中定义了 Get_{field}/Set_{field} 函数，
+ * 生成的属性会优先调用这些函数；否则直接访问字段本身。
+ *  - SW_DEFINE_PROPERTY(name, field)
+ *  - SW_DEFINE_READONLY_PROPERTY(name, field)
+ *  - SW_DEFINE_WRITEONLY_PROPERTY(name, field)
+ *  - SW_DEFINE_NOTIFY_PROPERTY(name, field)
  *
- * SW_DEFINE_EXPR_*_PROPERTY系列宏：
- * 用于简化对this->{expr}表达式的属性封装，当表达式结果是属性时会进行转发调用，否则直接访问表达式本身，该系列宏
- * 不支持自定义Getter和Setter函数。
- *
- * - SW_DEFINE_EXPR_PROPERTY(name, expr)
- * - SW_DEFINE_EXPR_READONLY_PROPERTY(name, expr)
- * - SW_DEFINE_EXPR_WRITEONLY_PROPERTY(name, expr)
- * - SW_DEFINE_EXPR_NOTIFY_PROPERTY(name, expr)
+ * @par SW_DEFINE_EXPR_*_PROPERTY 系列（基于表达式）
+ * 对形如 this->{expr} 的表达式进行属性封装。当表达式结果是另一个属性时，
+ * Get/Set 会转发到该属性；否则直接读写表达式。该系列不支持自定义 Getter/Setter。
+ *  - SW_DEFINE_EXPR_PROPERTY(name, expr)
+ *  - SW_DEFINE_EXPR_READONLY_PROPERTY(name, expr)
+ *  - SW_DEFINE_EXPR_WRITEONLY_PROPERTY(name, expr)
+ *  - SW_DEFINE_EXPR_NOTIFY_PROPERTY(name, expr)
  */
 
 /*================================================================================*/
 
 /**
- * _Get_{field name}: 当前类有自定义的Get_{field name}函数时，调用该函数获取field值，否则直接访问field字段
+ * @brief 在类内定义读取字段值的静态分发函数 _Get_##field（及配套 trait _HasUserGetter_##field）
+ * @param field 类中已声明的非静态数据成员名
+ * @note 若类中存在自定义 Get_##field()，_Get_##field 转发调用之；否则直接返回 self.field 的引用
  */
 #define _SW_DEFINE_STATIC_GETTER(field)                                                                  \
     template <typename T, typename = void>                                                               \
@@ -51,7 +54,9 @@
     }
 
 /**
- * _Set_{field name}: 当前类有自定义的Set_{field name}函数时，调用该函数设置field值，否则直接访问field字段
+ * @brief 在类内定义写入字段值的静态分发函数 _Set_##field（及配套 trait _HasUserSetter_##field）
+ * @param field 类中已声明的非静态数据成员名
+ * @note 若类中存在自定义 Set_##field()，_Set_##field 转发调用之；否则直接对 self.field 赋值
  */
 #define _SW_DEFINE_STATIC_SETTER(field)                                                  \
     template <typename T, typename = void>                                               \
@@ -76,7 +81,10 @@
 /*================================================================================*/
 
 /**
- * 定义基于字段的属性，若类中有自定义的Get_{field name}和Set_{field name}函数，则会调用这些函数，否则直接访问字段
+ * @brief 定义基于字段的可读写属性
+ * @param name 生成的 sw::Property 成员名
+ * @param field 类中已声明的非静态数据成员名
+ * @note 类中存在自定义 Get_##field/Set_##field 时优先调用，否则直接访问字段
  */
 #define SW_DEFINE_PROPERTY(name, field)           \
     _SW_DEFINE_STATIC_GETTER(field);              \
@@ -93,7 +101,10 @@
     }
 
 /**
- * 定义基于字段的只读属性，若类中有自定义的Get_{field name}函数，则会调用该函数，否则直接访问字段
+ * @brief 定义基于字段的只读属性
+ * @param name 生成的 sw::ReadOnlyProperty 成员名
+ * @param field 类中已声明的非静态数据成员名
+ * @note 类中存在自定义 Get_##field 时优先调用，否则直接访问字段
  */
 #define SW_DEFINE_READONLY_PROPERTY(name, field)  \
     _SW_DEFINE_STATIC_GETTER(field);              \
@@ -106,7 +117,10 @@
     }
 
 /**
- * 定义基于字段的只写属性，若类中有自定义的Set_{field name}函数，则会调用该函数，否则直接访问字段
+ * @brief 定义基于字段的只写属性
+ * @param name 生成的 sw::WriteOnlyProperty 成员名
+ * @param field 类中已声明的非静态数据成员名
+ * @note 类中存在自定义 Set_##field 时优先调用，否则直接访问字段
  */
 #define SW_DEFINE_WRITEONLY_PROPERTY(name, field) \
     _SW_DEFINE_STATIC_SETTER(field);              \
@@ -119,8 +133,13 @@
     }
 
 /**
- * 定义基于字段的通知属性，若类中有自定义的Get_{field name}和Set_{field name}函数，则会调用这些函数，否则直接访问字段
- * 该宏应在实现了INotifyPropertyChanged接口的类中使用，若未自定义Setter则会尝试比较并在字段发生变更时触发属性变更通知
+ * @brief 定义基于字段的通知属性，赋值时通过 PropertyChanged 派发变更通知
+ * @param name 生成的 sw::Property 成员名
+ * @param field 类中已声明的非静态数据成员名
+ * @note 应在派生自 sw::INotifyPropertyChanged 的类中使用。
+ *       类中存在自定义 Get_##field/Set_##field 时优先调用，否则直接访问字段。
+ *       未自定义 Setter 时：若字段类型支持 == 比较则先比较，仅在值发生变更时触发 PropertyChanged；
+ *       不支持 == 比较时每次赋值都触发。自定义 Setter 时由用户负责通知（宏不主动触发）。
  */
 #define SW_DEFINE_NOTIFY_PROPERTY(name, field)                                                    \
     _SW_DEFINE_STATIC_GETTER(field);                                                              \
@@ -178,7 +197,9 @@
 /*================================================================================*/
 
 /**
- * 定义表达式属性值类型辅助模板结构体
+ * @brief 定义计算表达式属性值类型的辅助模板 _ExprPropertyValueTypeHelper_##propname
+ * @param propname 属性名
+ * @note 表达式类型为属性时 type 取属性的 TValue；否则取 std::decay 后的表达式类型
  */
 #define _SW_DEFINE_EXPR_PROPERTY_VALUETYPE_HELPER(propname)                    \
     template <typename TExpr, typename = void>                                 \
@@ -192,13 +213,18 @@
     }
 
 /**
- * 计算表达式的值类型，若表达式是属性则取其属性值类型，否则取表达式类型本身
+ * @brief 取出表达式对应的属性值类型（属性时为其 TValue，否则为 decay 后的表达式类型）
+ * @param propname 属性名
+ * @param expr 形如 self->{expr} 的表达式片段
  */
 #define _SW_EXPR_PROPERTY_VALUETYPE(propname, expr) \
     typename _ExprPropertyValueTypeHelper_##propname<decltype(expr)>::type
 
 /**
- * _Get_{propname}: 若表达式是属性则调用其Get函数获取值，否则直接访问表达式
+ * @brief 在类内定义读取表达式值的静态分发函数 _Get_##propname
+ * @param propname 属性名
+ * @param expr 形如 self->{expr} 的表达式片段
+ * @note 表达式结果为属性时调用其 Get()，否则直接读取表达式
  */
 #define _SW_DEFINE_EXPR_STATIC_GETTER(propname, expr)                                   \
     template <typename T, typename U = decltype(expr)>                                  \
@@ -215,7 +241,10 @@
     }
 
 /**
- * _Set_{propname}: 若表达式是属性则调用其Set函数设置值，否则直接访问表达式
+ * @brief 在类内定义写入表达式值的静态分发函数 _Set_##propname
+ * @param propname 属性名
+ * @param expr 形如 self->{expr} 的表达式片段
+ * @note 表达式结果为属性时调用其 Set()，否则直接对表达式赋值
  */
 #define _SW_DEFINE_EXPR_STATIC_SETTER(propname, expr)                \
     template <typename T, typename U, typename V = decltype(expr)>   \
@@ -234,8 +263,10 @@
 /*================================================================================*/
 
 /**
- * 定义基于表达式的属性，访问this->{expr}，不支持自定义Getter和Setter
- * 当表达式为属性时，Getter和Setter会调用该属性的Get和Set函数，否则直接访问表达式
+ * @brief 定义基于表达式 self->{expr} 的可读写属性，不支持自定义 Getter/Setter
+ * @param name 生成的 sw::Property 成员名
+ * @param expr 形如 self->{expr} 的表达式片段
+ * @note 表达式结果为属性时转发到其 Get/Set，否则直接访问表达式
  */
 #define SW_DEFINE_EXPR_PROPERTY(name, expr)                               \
     _SW_DEFINE_EXPR_PROPERTY_VALUETYPE_HELPER(name);                      \
@@ -253,8 +284,10 @@
     }
 
 /**
- * 定义基于表达式的只读属性，访问this->{expr}，不支持自定义Getter
- * 当表达式为属性时，Getter会调用该属性的Get函数，否则直接访问表达式
+ * @brief 定义基于表达式 self->{expr} 的只读属性，不支持自定义 Getter
+ * @param name 生成的 sw::ReadOnlyProperty 成员名
+ * @param expr 形如 self->{expr} 的表达式片段
+ * @note 表达式结果为属性时调用其 Get()，否则直接读取表达式
  */
 #define SW_DEFINE_EXPR_READONLY_PROPERTY(name, expr)                      \
     _SW_DEFINE_EXPR_PROPERTY_VALUETYPE_HELPER(name);                      \
@@ -268,8 +301,10 @@
     }
 
 /**
- * 定义基于表达式的只写属性，访问this->{expr}，不支持自定义Setter
- * 当表达式为属性时，Setter会调用该属性的Set函数，否则直接访问表达式
+ * @brief 定义基于表达式 self->{expr} 的只写属性，不支持自定义 Setter
+ * @param name 生成的 sw::WriteOnlyProperty 成员名
+ * @param expr 形如 self->{expr} 的表达式片段
+ * @note 表达式结果为属性时调用其 Set()，否则直接对表达式赋值
  */
 #define SW_DEFINE_EXPR_WRITEONLY_PROPERTY(name, expr)                     \
     _SW_DEFINE_EXPR_PROPERTY_VALUETYPE_HELPER(name);                      \
@@ -283,9 +318,13 @@
     }
 
 /**
- * 定义基于表达式的通知属性，访问this->{expr}，不支持自定义Getter和Setter
- * 当表达式为属性时，Getter和Setter会调用该属性的Get和Set函数，否则直接访问表达式
- * 该宏应在实现了INotifyPropertyChanged接口的类中使用，Setter会尝试比较并在表达式的值发生变更时触发属性变更通知
+ * @brief 定义基于表达式 self->{expr} 的通知属性，赋值时通过 PropertyChanged 派发变更通知
+ * @param name 生成的 sw::Property 成员名
+ * @param expr 形如 self->{expr} 的表达式片段
+ * @note 应在派生自 sw::INotifyPropertyChanged 的类中使用。
+ *       表达式结果为属性时转发到其 Get/Set，否则直接访问表达式；
+ *       Setter 在类型支持 == 比较时先比较，仅在值发生变更时触发 PropertyChanged；
+ *       不支持 == 比较时每次赋值都触发。
  */
 #define SW_DEFINE_EXPR_NOTIFY_PROPERTY(name, expr)                        \
     _SW_DEFINE_EXPR_PROPERTY_VALUETYPE_HELPER(name);                      \

--- a/sw/inc/Macros.h
+++ b/sw/inc/Macros.h
@@ -47,7 +47,7 @@
     static auto _Get_##field(T &self)                                                                    \
         -> typename std::enable_if<!_HasUserGetter_##field<T>::value, decltype(T::field) &>::type        \
     {                                                                                                    \
-        return self.##field;                                                                             \
+        return self.field;                                                                               \
     }
 
 /**
@@ -70,7 +70,7 @@
     static auto _Set_##field(T &self, U &&value)                                         \
         -> typename std::enable_if<!_HasUserSetter_##field<T>::value>::type              \
     {                                                                                    \
-        self.##field = std::forward<U>(value);                                           \
+        self.field = std::forward<U>(value);                                             \
     }
 
 /*================================================================================*/
@@ -141,16 +141,16 @@
         -> typename std::enable_if<!_HasUserSetter_##field<T>::value && sw::_EqOperationHelper<U, U>::value>::type  \
     {                                                                                                               \
         if (!(_Get_##field(self) == value)) {                                                                       \
-            self.##field = std::forward<U>(value);                                                                  \
-            if (self.PropertyChanged) self.PropertyChanged(self, sw::Reflection::GetFieldId(&T::##name));           \
+            self.field = std::forward<U>(value);                                                                    \
+            if (self.PropertyChanged) self.PropertyChanged(self, sw::Reflection::GetFieldId(&T::name));             \
         }                                                                                                           \
     }                                                                                                               \
     template <typename T, typename U>                                                                               \
     static auto _Set_##field(T &self, U &&value)                                                                    \
         -> typename std::enable_if<!_HasUserSetter_##field<T>::value && !sw::_EqOperationHelper<U, U>::value>::type \
     {                                                                                                               \
-        self.##field = std::forward<U>(value);                                                                      \
-        if (self.PropertyChanged) self.PropertyChanged(self, sw::Reflection::GetFieldId(&T::##name));               \
+        self.field = std::forward<U>(value);                                                                        \
+        if (self.PropertyChanged) self.PropertyChanged(self, sw::Reflection::GetFieldId(&T::name));                 \
     }                                                                                                               \
     sw::Property<decltype(field)> name                                                                              \
     {                                                                                                               \
@@ -193,13 +193,13 @@
     static auto _Get_##propname(T &self)                                                \
         -> typename std::enable_if<sw::_IsProperty<U>::value, typename U::TValue>::type \
     {                                                                                   \
-        return (self.##expr).Get();                                                     \
+        return (self.expr).Get();                                                       \
     }                                                                                   \
     template <typename T, typename U = decltype(expr)>                                  \
     static auto _Get_##propname(T &self)                                                \
         -> typename std::enable_if<!sw::_IsProperty<U>::value, U>::type                 \
     {                                                                                   \
-        return (self.##expr);                                                           \
+        return (self.expr);                                                             \
     }
 
 /**
@@ -210,13 +210,13 @@
     static auto _Set_##propname(T &self, U &&value)                  \
         -> typename std::enable_if<sw::_IsProperty<V>::value>::type  \
     {                                                                \
-        (self.##expr).Set(std::forward<U>(value));                   \
+        (self.expr).Set(std::forward<U>(value));                     \
     }                                                                \
     template <typename T, typename U, typename V = decltype(expr)>   \
     static auto _Set_##propname(T &self, U &&value)                  \
         -> typename std::enable_if<!sw::_IsProperty<V>::value>::type \
     {                                                                \
-        (self.##expr) = std::forward<U>(value);                      \
+        (self.expr) = std::forward<U>(value);                        \
     }
 
 /*================================================================================*/
@@ -282,33 +282,33 @@
     static auto _Set_##name(T &self, U &&value)                                                              \
         -> typename std::enable_if<sw::_IsProperty<V>::value && sw::_EqOperationHelper<U, U>::value>::type   \
     {                                                                                                        \
-        if (!((self.##expr).Get() == value)) {                                                               \
-            (self.##expr).Set(std::forward<U>(value));                                                       \
-            if (self.PropertyChanged) self.PropertyChanged(self, sw::Reflection::GetFieldId(&T::##name));    \
+        if (!((self.expr).Get() == value)) {                                                                 \
+            (self.expr).Set(std::forward<U>(value));                                                         \
+            if (self.PropertyChanged) self.PropertyChanged(self, sw::Reflection::GetFieldId(&T::name));      \
         }                                                                                                    \
     }                                                                                                        \
     template <typename T, typename U, typename V = decltype(expr)>                                           \
     static auto _Set_##name(T &self, U &&value)                                                              \
         -> typename std::enable_if<sw::_IsProperty<V>::value && !sw::_EqOperationHelper<U, U>::value>::type  \
     {                                                                                                        \
-        (self.##expr).Set(std::forward<U>(value));                                                           \
-        if (self.PropertyChanged) self.PropertyChanged(self, sw::Reflection::GetFieldId(&T::##name));        \
+        (self.expr).Set(std::forward<U>(value));                                                             \
+        if (self.PropertyChanged) self.PropertyChanged(self, sw::Reflection::GetFieldId(&T::name));          \
     }                                                                                                        \
     template <typename T, typename U, typename V = decltype(expr)>                                           \
     static auto _Set_##name(T &self, U &&value)                                                              \
         -> typename std::enable_if<!sw::_IsProperty<V>::value && sw::_EqOperationHelper<U, U>::value>::type  \
     {                                                                                                        \
-        if (!((self.##expr) == value)) {                                                                     \
-            (self.##expr) = std::forward<U>(value);                                                          \
-            if (self.PropertyChanged) self.PropertyChanged(self, sw::Reflection::GetFieldId(&T::##name));    \
+        if (!((self.expr) == value)) {                                                                       \
+            (self.expr) = std::forward<U>(value);                                                            \
+            if (self.PropertyChanged) self.PropertyChanged(self, sw::Reflection::GetFieldId(&T::name));      \
         }                                                                                                    \
     }                                                                                                        \
     template <typename T, typename U, typename V = decltype(expr)>                                           \
     static auto _Set_##name(T &self, U &&value)                                                              \
         -> typename std::enable_if<!sw::_IsProperty<V>::value && !sw::_EqOperationHelper<U, U>::value>::type \
     {                                                                                                        \
-        (self.##expr) = std::forward<U>(value);                                                              \
-        if (self.PropertyChanged) self.PropertyChanged(self, sw::Reflection::GetFieldId(&T::##name));        \
+        (self.expr) = std::forward<U>(value);                                                                \
+        if (self.PropertyChanged) self.PropertyChanged(self, sw::Reflection::GetFieldId(&T::name));          \
     }                                                                                                        \
     sw::Property<_SW_EXPR_PROPERTY_VALUETYPE(name, expr)> name                                               \
     {                                                                                                        \

--- a/sw/inc/Macros.h
+++ b/sw/inc/Macros.h
@@ -122,45 +122,57 @@
  * 定义基于字段的通知属性，若类中有自定义的Get_{field name}和Set_{field name}函数，则会调用这些函数，否则直接访问字段
  * 该宏应在实现了INotifyPropertyChanged接口的类中使用，若未自定义Setter则会尝试比较并在字段发生变更时触发属性变更通知
  */
-#define SW_DEFINE_NOTIFY_PROPERTY(name, field)                                                                      \
-    _SW_DEFINE_STATIC_GETTER(field);                                                                                \
-    template <typename T, typename = void>                                                                          \
-    struct _HasUserSetter_##field : std::false_type {                                                               \
-    };                                                                                                              \
-    template <typename T>                                                                                           \
-    struct _HasUserSetter_##field<T, decltype(void(&T::Set_##field))> : std::true_type {                            \
-    };                                                                                                              \
-    template <typename T, typename U>                                                                               \
-    static auto _Set_##field(T &self, U &&value)                                                                    \
-        -> typename std::enable_if<_HasUserSetter_##field<T>::value>::type                                          \
-    {                                                                                                               \
-        self.Set_##field(std::forward<U>(value));                                                                   \
-    }                                                                                                               \
-    template <typename T, typename U>                                                                               \
-    static auto _Set_##field(T &self, U &&value)                                                                    \
-        -> typename std::enable_if<!_HasUserSetter_##field<T>::value && sw::_EqOperationHelper<U, U>::value>::type  \
-    {                                                                                                               \
-        if (!(_Get_##field(self) == value)) {                                                                       \
-            self.field = std::forward<U>(value);                                                                    \
-            if (self.PropertyChanged) self.PropertyChanged(self, sw::Reflection::GetFieldId(&T::name));             \
-        }                                                                                                           \
-    }                                                                                                               \
-    template <typename T, typename U>                                                                               \
-    static auto _Set_##field(T &self, U &&value)                                                                    \
-        -> typename std::enable_if<!_HasUserSetter_##field<T>::value && !sw::_EqOperationHelper<U, U>::value>::type \
-    {                                                                                                               \
-        self.field = std::forward<U>(value);                                                                        \
-        if (self.PropertyChanged) self.PropertyChanged(self, sw::Reflection::GetFieldId(&T::name));                 \
-    }                                                                                                               \
-    sw::Property<decltype(field)> name                                                                              \
-    {                                                                                                               \
-        sw::Property<decltype(field)>::Init(this)                                                                   \
-            .Getter([](auto self) {                                                                                 \
-                return _Get_##field(*self);                                                                         \
-            })                                                                                                      \
-            .Setter([](auto self, auto value) {                                                                     \
-                _Set_##field(*self, value);                                                                         \
-            })                                                                                                      \
+#define SW_DEFINE_NOTIFY_PROPERTY(name, field)                                                    \
+    _SW_DEFINE_STATIC_GETTER(field);                                                              \
+    template <typename T, typename = void>                                                        \
+    struct _HasUserSetter_##field : std::false_type {                                             \
+    };                                                                                            \
+    template <typename T>                                                                         \
+    struct _HasUserSetter_##field<T, decltype(void(&T::Set_##field))> : std::true_type {          \
+    };                                                                                            \
+    template <typename T, typename U>                                                             \
+    static auto _Set_##field(T &self, U &&value)                                                  \
+        -> typename std::enable_if<_HasUserSetter_##field<T>::value>::type                        \
+    {                                                                                             \
+        self.Set_##field(std::forward<U>(value));                                                 \
+    }                                                                                             \
+    template <typename T, typename U>                                                             \
+    static auto _Set_##field(T &self, U &&value)                                                  \
+        -> typename std::enable_if<                                                               \
+            !_HasUserSetter_##field<T>::value &&                                                  \
+            sw::_EqOperationHelper<decltype(_Get_##field(std::declval<T &>())), U>::value>::type  \
+    {                                                                                             \
+        if (!(_Get_##field(self) == value)) {                                                     \
+            self.field = std::forward<U>(value);                                                  \
+            if (auto &_d = self.GetPropertyChangedEventDelegate()) {                              \
+                sw::PropertyChangedEventArgs _a{};                                                \
+                _a.propertyId = sw::Reflection::GetFieldId(&T::name);                             \
+                _d(self, _a);                                                                     \
+            }                                                                                     \
+        }                                                                                         \
+    }                                                                                             \
+    template <typename T, typename U>                                                             \
+    static auto _Set_##field(T &self, U &&value)                                                  \
+        -> typename std::enable_if<                                                               \
+            !_HasUserSetter_##field<T>::value &&                                                  \
+            !sw::_EqOperationHelper<decltype(_Get_##field(std::declval<T &>())), U>::value>::type \
+    {                                                                                             \
+        self.field = std::forward<U>(value);                                                      \
+        if (auto &_d = self.GetPropertyChangedEventDelegate()) {                                  \
+            sw::PropertyChangedEventArgs _a{};                                                    \
+            _a.propertyId = sw::Reflection::GetFieldId(&T::name);                                 \
+            _d(self, _a);                                                                         \
+        }                                                                                         \
+    }                                                                                             \
+    sw::Property<decltype(field)> name                                                            \
+    {                                                                                             \
+        sw::Property<decltype(field)>::Init(this)                                                 \
+            .Getter([](auto self) {                                                               \
+                return _Get_##field(*self);                                                       \
+            })                                                                                    \
+            .Setter([](auto self, auto value) {                                                   \
+                _Set_##field(*self, value);                                                       \
+            })                                                                                    \
     }
 
 /*================================================================================*/
@@ -275,50 +287,74 @@
  * 当表达式为属性时，Getter和Setter会调用该属性的Get和Set函数，否则直接访问表达式
  * 该宏应在实现了INotifyPropertyChanged接口的类中使用，Setter会尝试比较并在表达式的值发生变更时触发属性变更通知
  */
-#define SW_DEFINE_EXPR_NOTIFY_PROPERTY(name, expr)                                                           \
-    _SW_DEFINE_EXPR_PROPERTY_VALUETYPE_HELPER(name);                                                         \
-    _SW_DEFINE_EXPR_STATIC_GETTER(name, expr);                                                               \
-    template <typename T, typename U, typename V = decltype(expr)>                                           \
-    static auto _Set_##name(T &self, U &&value)                                                              \
-        -> typename std::enable_if<sw::_IsProperty<V>::value && sw::_EqOperationHelper<U, U>::value>::type   \
-    {                                                                                                        \
-        if (!((self.expr).Get() == value)) {                                                                 \
-            (self.expr).Set(std::forward<U>(value));                                                         \
-            if (self.PropertyChanged) self.PropertyChanged(self, sw::Reflection::GetFieldId(&T::name));      \
-        }                                                                                                    \
-    }                                                                                                        \
-    template <typename T, typename U, typename V = decltype(expr)>                                           \
-    static auto _Set_##name(T &self, U &&value)                                                              \
-        -> typename std::enable_if<sw::_IsProperty<V>::value && !sw::_EqOperationHelper<U, U>::value>::type  \
-    {                                                                                                        \
-        (self.expr).Set(std::forward<U>(value));                                                             \
-        if (self.PropertyChanged) self.PropertyChanged(self, sw::Reflection::GetFieldId(&T::name));          \
-    }                                                                                                        \
-    template <typename T, typename U, typename V = decltype(expr)>                                           \
-    static auto _Set_##name(T &self, U &&value)                                                              \
-        -> typename std::enable_if<!sw::_IsProperty<V>::value && sw::_EqOperationHelper<U, U>::value>::type  \
-    {                                                                                                        \
-        if (!((self.expr) == value)) {                                                                       \
-            (self.expr) = std::forward<U>(value);                                                            \
-            if (self.PropertyChanged) self.PropertyChanged(self, sw::Reflection::GetFieldId(&T::name));      \
-        }                                                                                                    \
-    }                                                                                                        \
-    template <typename T, typename U, typename V = decltype(expr)>                                           \
-    static auto _Set_##name(T &self, U &&value)                                                              \
-        -> typename std::enable_if<!sw::_IsProperty<V>::value && !sw::_EqOperationHelper<U, U>::value>::type \
-    {                                                                                                        \
-        (self.expr) = std::forward<U>(value);                                                                \
-        if (self.PropertyChanged) self.PropertyChanged(self, sw::Reflection::GetFieldId(&T::name));          \
-    }                                                                                                        \
-    sw::Property<_SW_EXPR_PROPERTY_VALUETYPE(name, expr)> name                                               \
-    {                                                                                                        \
-        sw::Property<_SW_EXPR_PROPERTY_VALUETYPE(name, expr)>::Init(this)                                    \
-            .Getter([](auto self) {                                                                          \
-                return _Get_##name(*self);                                                                   \
-            })                                                                                               \
-            .Setter([](auto self, auto value) {                                                              \
-                _Set_##name(*self, value);                                                                   \
-            })                                                                                               \
+#define SW_DEFINE_EXPR_NOTIFY_PROPERTY(name, expr)                        \
+    _SW_DEFINE_EXPR_PROPERTY_VALUETYPE_HELPER(name);                      \
+    _SW_DEFINE_EXPR_STATIC_GETTER(name, expr);                            \
+    template <typename T, typename U, typename V = decltype(expr)>        \
+    static auto _Set_##name(T &self, U &&value)                           \
+        -> typename std::enable_if<                                       \
+            sw::_IsProperty<V>::value &&                                  \
+            sw::_EqOperationHelper<typename V::TValue, U>::value>::type   \
+    {                                                                     \
+        if (!((self.expr).Get() == value)) {                              \
+            (self.expr).Set(std::forward<U>(value));                      \
+            if (auto &_d = self.GetPropertyChangedEventDelegate()) {      \
+                sw::PropertyChangedEventArgs _a{};                        \
+                _a.propertyId = sw::Reflection::GetFieldId(&T::name);     \
+                _d(self, _a);                                             \
+            }                                                             \
+        }                                                                 \
+    }                                                                     \
+    template <typename T, typename U, typename V = decltype(expr)>        \
+    static auto _Set_##name(T &self, U &&value)                           \
+        -> typename std::enable_if<                                       \
+            sw::_IsProperty<V>::value &&                                  \
+            !sw::_EqOperationHelper<typename V::TValue, U>::value>::type  \
+    {                                                                     \
+        (self.expr).Set(std::forward<U>(value));                          \
+        if (auto &_d = self.GetPropertyChangedEventDelegate()) {          \
+            sw::PropertyChangedEventArgs _a{};                            \
+            _a.propertyId = sw::Reflection::GetFieldId(&T::name);         \
+            _d(self, _a);                                                 \
+        }                                                                 \
+    }                                                                     \
+    template <typename T, typename U, typename V = decltype(expr)>        \
+    static auto _Set_##name(T &self, U &&value)                           \
+        -> typename std::enable_if<                                       \
+            !sw::_IsProperty<V>::value &&                                 \
+            sw::_EqOperationHelper<V, U>::value>::type                    \
+    {                                                                     \
+        if (!((self.expr) == value)) {                                    \
+            (self.expr) = std::forward<U>(value);                         \
+            if (auto &_d = self.GetPropertyChangedEventDelegate()) {      \
+                sw::PropertyChangedEventArgs _a{};                        \
+                _a.propertyId = sw::Reflection::GetFieldId(&T::name);     \
+                _d(self, _a);                                             \
+            }                                                             \
+        }                                                                 \
+    }                                                                     \
+    template <typename T, typename U, typename V = decltype(expr)>        \
+    static auto _Set_##name(T &self, U &&value)                           \
+        -> typename std::enable_if<                                       \
+            !sw::_IsProperty<V>::value &&                                 \
+            !sw::_EqOperationHelper<V, U>::value>::type                   \
+    {                                                                     \
+        (self.expr) = std::forward<U>(value);                             \
+        if (auto &_d = self.GetPropertyChangedEventDelegate()) {          \
+            sw::PropertyChangedEventArgs _a{};                            \
+            _a.propertyId = sw::Reflection::GetFieldId(&T::name);         \
+            _d(self, _a);                                                 \
+        }                                                                 \
+    }                                                                     \
+    sw::Property<_SW_EXPR_PROPERTY_VALUETYPE(name, expr)> name            \
+    {                                                                     \
+        sw::Property<_SW_EXPR_PROPERTY_VALUETYPE(name, expr)>::Init(this) \
+            .Getter([](auto self) {                                       \
+                return _Get_##name(*self);                                \
+            })                                                            \
+            .Setter([](auto self, auto value) {                           \
+                _Set_##name(*self, value);                                \
+            })                                                            \
     }
 
 /*================================================================================*/

--- a/sw/inc/ObservableObject.h
+++ b/sw/inc/ObservableObject.h
@@ -25,6 +25,50 @@ namespace sw
 
     public:
         /**
+         * @brief 默认构造函数
+         */
+        ObservableObject() = default;
+
+        /**
+         * @brief 禁用拷贝构造
+         * @note 事件订阅不应随对象拷贝传播，否则订阅者会收到来自副本的额外通知
+         */
+        ObservableObject(const ObservableObject &) = delete;
+
+        /**
+         * @brief 禁用拷贝赋值
+         * @note 事件订阅不应随对象拷贝传播，否则订阅者会收到来自副本的额外通知
+         */
+        ObservableObject &operator=(const ObservableObject &) = delete;
+
+        /**
+         * @brief 移动构造函数
+         * @note 将事件订阅从被移动对象转移到新对象
+         */
+        ObservableObject(ObservableObject &&other) noexcept
+            : DynamicObject(std::move(other)),
+              INotifyObjectDead(std::move(other)),
+              INotifyPropertyChanged(std::move(other)),
+              _propertyChanged(std::move(other._propertyChanged)),
+              _objectDead(std::move(other._objectDead))
+        {
+        }
+
+        /**
+         * @brief 移动赋值运算符
+         * @note 将事件订阅从被移动对象转移到当前对象，覆盖当前对象已有的订阅
+         */
+        ObservableObject &operator=(ObservableObject &&other) noexcept
+        {
+            if (this != &other) {
+                DynamicObject::operator=(std::move(other));
+                _propertyChanged = std::move(other._propertyChanged);
+                _objectDead      = std::move(other._objectDead);
+            }
+            return *this;
+        }
+
+        /**
          * @brief 析构时触发对象销毁事件
          */
         virtual ~ObservableObject()

--- a/sw/inc/Point.h
+++ b/sw/inc/Point.h
@@ -31,22 +31,22 @@ namespace sw
         /**
          * @brief 构造指定xy值的Point结构体
          */
-        Point(double x, double y);
+        Point(double x, double y) noexcept;
 
         /**
          * @brief 从POINT构造Point结构体
          */
-        Point(const POINT &point);
+        Point(const POINT &point) noexcept;
 
         /**
          * @brief 隐式转换POINT
          */
-        operator POINT() const;
+        operator POINT() const noexcept;
 
         /**
          * @brief 判断两个Point是否相等
          */
-        bool Equals(const Point &other) const;
+        bool Equals(const Point &other) const noexcept;
 
         /**
          * @brief 获取描述当前对象的字符串

--- a/sw/inc/Property.h
+++ b/sw/inc/Property.h
@@ -1418,6 +1418,9 @@ namespace sw
 
         /**
          * @brief 下标运算
+         * @note 仅在T的operator[]返回非引用类型时启用：Get()可能返回临时对象，
+         *       若T的operator[]返回引用，将产生悬空引用，因此不允许通过属性的
+         *       operator[]直接访问返回引用的重载，应先将Get()的结果保存到变量后再使用。
          */
         template <typename U>
         auto operator[](U &&value) const
@@ -1431,6 +1434,9 @@ namespace sw
 
         /**
          * @brief 下标运算
+         * @note 仅在T的operator[]返回非引用类型时启用：Get()可能返回临时对象，
+         *       若T的operator[]返回引用，将产生悬空引用，因此不允许通过属性的
+         *       operator[]直接访问返回引用的重载，应先将Get()的结果保存到变量后再使用。
          */
         template <typename D, typename U>
         auto operator[](const PropertyBase<U, D> &prop) const
@@ -1444,6 +1450,8 @@ namespace sw
 
         /**
          * @brief 指针下标运算
+         * @note T为指针时，Get()返回的指针虽是临时对象，但其指向的内存独立存在，
+         *       故此处即使operator[]返回引用也不会产生悬空引用，无需限制返回类型。
          */
         template <typename U>
         auto operator[](U &&value) const
@@ -1456,6 +1464,8 @@ namespace sw
 
         /**
          * @brief 指针下标运算
+         * @note T为指针时，Get()返回的指针虽是临时对象，但其指向的内存独立存在，
+         *       故此处即使operator[]返回引用也不会产生悬空引用，无需限制返回类型。
          */
         template <typename D, typename U>
         auto operator[](const PropertyBase<U, D> &prop) const

--- a/sw/inc/Property.h
+++ b/sw/inc/Property.h
@@ -204,7 +204,8 @@ namespace sw
          * @brief 指针类型，直接返回值
          */
         template <typename U = T>
-        typename std::enable_if<std::is_pointer<U>::value, U>::type operator->()
+        auto operator->()
+            -> typename std::enable_if<std::is_pointer<U>::value, U>::type
         {
             return this->value;
         }
@@ -213,7 +214,8 @@ namespace sw
          * @brief 非指针类型，且无operator->，返回值的地址
          */
         template <typename U = T>
-        typename std::enable_if<!std::is_pointer<U>::value && !_HasArrowOperator<U>::value, U *>::type operator->()
+        auto operator->()
+            -> typename std::enable_if<!std::is_pointer<U>::value && !_HasArrowOperator<U>::value, U *>::type
         {
             return &this->value;
         }
@@ -222,7 +224,8 @@ namespace sw
          * @brief 非指针类型，且有operator->，转发operator->
          */
         template <typename U = T>
-        typename std::enable_if<!std::is_pointer<U>::value && _HasArrowOperator<U>::value, typename _HasArrowOperator<U>::type>::type operator->()
+        auto operator->()
+            -> typename std::enable_if<!std::is_pointer<U>::value && _HasArrowOperator<U>::value, typename _HasArrowOperator<U>::type>::type
         {
             return this->value.operator->();
         }
@@ -1512,7 +1515,8 @@ namespace sw
          * @brief 获取成员属性初始化器
          */
         template <typename TOwner>
-        static MemberPropertyInitializer<TOwner, T> Init(TOwner *owner)
+        static auto Init(TOwner *owner)
+            -> MemberPropertyInitializer<TOwner, T>
         {
             return MemberPropertyInitializer<TOwner, T>(owner);
         }
@@ -1520,7 +1524,8 @@ namespace sw
         /**
          * @brief 获取静态属性初始化器
          */
-        static StaticPropertyInitializer<T> Init()
+        static auto Init()
+            -> StaticPropertyInitializer<T>
         {
             return StaticPropertyInitializer<T>();
         }

--- a/sw/inc/Property.h
+++ b/sw/inc/Property.h
@@ -1488,6 +1488,13 @@ namespace sw
 
     protected:
         /**
+         * @brief 用于存储任意签名函数指针的通用类型
+         * @note 函数指针类型间通过reinterpret_cast互转再转回原类型不丢失信息（C++标准良定义），
+         *       使用统一的函数指针类型作为存储可避免函数指针与void*之间的conditionally-supported转换。
+         */
+        using TFuncPtr = void (*)();
+
+        /**
          * @brief 静态属性偏移量标记
          */
         static constexpr std::ptrdiff_t _STATICOFFSET =
@@ -1746,6 +1753,7 @@ namespace sw
         using TBase         = PropertyBase<T, Property<T>>;
         using TValue        = typename TBase::TValue;
         using TSetterParam  = typename TBase::TSetterParam;
+        using TFuncPtr      = typename TBase::TFuncPtr;
         using TGetter       = T (*)(void *);
         using TSetter       = void (*)(void *, TSetterParam);
         using TStaticGetter = T (*)();
@@ -1755,12 +1763,12 @@ namespace sw
         /**
          * @brief getter函数指针
          */
-        void *_getter;
+        TFuncPtr _getter;
 
         /**
          * @brief setter函数指针
          */
-        void *_setter;
+        TFuncPtr _setter;
 
     public:
         /**
@@ -1779,8 +1787,8 @@ namespace sw
             assert(initializer._setter != nullptr);
 
             this->SetOwner(initializer._owner);
-            this->_getter = reinterpret_cast<void *>(initializer._getter);
-            this->_setter = reinterpret_cast<void *>(initializer._setter);
+            this->_getter = reinterpret_cast<TFuncPtr>(initializer._getter);
+            this->_setter = reinterpret_cast<TFuncPtr>(initializer._setter);
         }
 
         /**
@@ -1792,8 +1800,8 @@ namespace sw
             assert(initializer._setter != nullptr);
 
             this->SetOwner(nullptr);
-            this->_getter = reinterpret_cast<void *>(initializer._getter);
-            this->_setter = reinterpret_cast<void *>(initializer._setter);
+            this->_getter = reinterpret_cast<TFuncPtr>(initializer._getter);
+            this->_setter = reinterpret_cast<TFuncPtr>(initializer._setter);
         }
 
         /**
@@ -1831,6 +1839,7 @@ namespace sw
         using TBase         = PropertyBase<T, ReadOnlyProperty<T>>;
         using TValue        = typename TBase::TValue;
         using TSetterParam  = typename TBase::TSetterParam;
+        using TFuncPtr      = typename TBase::TFuncPtr;
         using TGetter       = T (*)(void *);
         using TStaticGetter = T (*)();
 
@@ -1838,7 +1847,7 @@ namespace sw
         /**
          * @brief getter函数指针
          */
-        void *_getter;
+        TFuncPtr _getter;
 
     public:
         /**
@@ -1851,7 +1860,7 @@ namespace sw
             assert(initializer._getter != nullptr);
 
             this->SetOwner(initializer._owner);
-            this->_getter = reinterpret_cast<void *>(initializer._getter);
+            this->_getter = reinterpret_cast<TFuncPtr>(initializer._getter);
         }
 
         /**
@@ -1862,7 +1871,7 @@ namespace sw
             assert(initializer._getter != nullptr);
 
             this->SetOwner(nullptr);
-            this->_getter = reinterpret_cast<void *>(initializer._getter);
+            this->_getter = reinterpret_cast<TFuncPtr>(initializer._getter);
         }
 
         /**
@@ -1888,6 +1897,7 @@ namespace sw
         using TBase         = PropertyBase<T, WriteOnlyProperty<T>>;
         using TValue        = typename TBase::TValue;
         using TSetterParam  = typename TBase::TSetterParam;
+        using TFuncPtr      = typename TBase::TFuncPtr;
         using TSetter       = void (*)(void *, TSetterParam);
         using TStaticSetter = void (*)(TSetterParam);
 
@@ -1895,7 +1905,7 @@ namespace sw
         /**
          * @brief setter函数指针
          */
-        void *_setter;
+        TFuncPtr _setter;
 
     public:
         /**
@@ -1913,7 +1923,7 @@ namespace sw
             assert(initializer._setter != nullptr);
 
             this->SetOwner(initializer._owner);
-            this->_setter = reinterpret_cast<void *>(initializer._setter);
+            this->_setter = reinterpret_cast<TFuncPtr>(initializer._setter);
         }
 
         /**
@@ -1924,7 +1934,7 @@ namespace sw
             assert(initializer._setter != nullptr);
 
             this->SetOwner(nullptr);
-            this->_setter = reinterpret_cast<void *>(initializer._setter);
+            this->_setter = reinterpret_cast<TFuncPtr>(initializer._setter);
         }
 
         /**

--- a/sw/inc/Property.h
+++ b/sw/inc/Property.h
@@ -68,7 +68,7 @@ namespace sw
     _SW_DEFINE_UNARY_OPERATION_HELPER(_LogicNotOperationHelper, !);
     _SW_DEFINE_UNARY_OPERATION_HELPER(_BitNotOperationHelper, ~);
     _SW_DEFINE_UNARY_OPERATION_HELPER(_DerefOperationHelper, *);
-    _SW_DEFINE_UNARY_OPERATION_HELPER(_AddrOperationHelper, &);
+    // _SW_DEFINE_UNARY_OPERATION_HELPER(_AddrOperationHelper, &);
     _SW_DEFINE_UNARY_OPERATION_HELPER(_UnaryPlusOperationHelper, +);
     _SW_DEFINE_UNARY_OPERATION_HELPER(_UnaryMinusOperationHelper, -);
     // _SW_DEFINE_UNARY_OPERATION_HELPER(_PreIncOperationHelper, ++);
@@ -1016,22 +1016,32 @@ namespace sw
 
         /**
          * @brief 解引用运算
+         * @note 仅在T的operator*返回非引用类型时启用：Get()可能返回临时对象，
+         *       若T的operator*返回引用，将产生悬空引用，因此不允许通过属性的
+         *       operator*直接访问返回引用的重载，应先将Get()的结果保存到变量后再使用。
          */
         template <typename U = T>
         auto operator*() const
-            -> typename std::enable_if<_DerefOperationHelper<U>::value, typename _DerefOperationHelper<U>::type>::type
+            -> typename std::enable_if<
+                _DerefOperationHelper<U>::value &&
+                    !std::is_reference<typename _DerefOperationHelper<U>::type>::value,
+                typename _DerefOperationHelper<U>::type>::type
         {
             return *this->Get();
         }
 
         /**
-         * @brief 地址运算
+         * @brief 指针解引用运算
+         * @note T为指针时，Get()返回的指针虽是临时对象，但其指向的内存独立存在，
+         *       故此处即使operator*返回引用也不会产生悬空引用，无需限制返回类型。
          */
         template <typename U = T>
-        auto operator&() const
-            -> typename std::enable_if<_AddrOperationHelper<U>::value, typename _AddrOperationHelper<U>::type>::type
+        auto operator*() const
+            -> typename std::enable_if<
+                _DerefOperationHelper<U>::value && std::is_pointer<T>::value,
+                typename _DerefOperationHelper<U>::type>::type
         {
-            return &this->Get();
+            return *this->Get();
         }
 
         /**

--- a/sw/inc/Rect.h
+++ b/sw/inc/Rect.h
@@ -43,32 +43,32 @@ namespace sw
         /**
          * @brief 构造Rect
          */
-        Rect(double left, double top, double width, double height);
+        Rect(double left, double top, double width, double height) noexcept;
 
         /**
          * @brief 从RECT构造Rect
          */
-        Rect(const RECT &rect);
+        Rect(const RECT &rect) noexcept;
 
         /**
          * @brief 隐式转换RECT
          */
-        operator RECT() const;
+        operator RECT() const noexcept;
 
         /**
          * @brief 获取Rect左上角的位置
          */
-        Point GetPos() const;
+        Point GetPos() const noexcept;
 
         /**
          * @brief 获取Rect的尺寸
          */
-        Size GetSize() const;
+        Size GetSize() const noexcept;
 
         /**
          * @brief 判断两个Rect是否相等
          */
-        bool Equals(const Rect &other) const;
+        bool Equals(const Rect &other) const noexcept;
 
         /**
          * @brief 获取描述当前对象的字符串

--- a/sw/inc/Rect.h
+++ b/sw/inc/Rect.h
@@ -52,6 +52,9 @@ namespace sw
 
         /**
          * @brief 隐式转换RECT
+         * @note 由于DIP↔像素之间存在非线性舍入，对从RECT构造的Rect再转回RECT
+         *       不保证与原始RECT逐字段相等：right/bottom由(left+width)/(top+height)
+         *       重新换算，在非整数倍DPI缩放下可能存在±1像素偏差
          */
         operator RECT() const noexcept;
 

--- a/sw/inc/Reflection.h
+++ b/sw/inc/Reflection.h
@@ -63,6 +63,18 @@ namespace sw
         }
 
         /**
+         * @brief 判断与另一DynamicObject是否引用同一对象
+         * @return 引用同一对象时返回true
+         * @note 若为引用装箱则比较被引用对象的地址
+         */
+        bool ReferenceEquals(const DynamicObject &other) const noexcept
+        {
+            if (IsBoxedObject() && other.IsBoxedObject())
+                return GetBoxedRawPtr() == other.GetBoxedRawPtr();
+            return this == &other;
+        }
+
+        /**
          * @brief 获取对象的类型信息
          * @return 对象的类型索引
          */

--- a/sw/inc/Size.h
+++ b/sw/inc/Size.h
@@ -31,22 +31,22 @@ namespace sw
         /**
          * @brief 构造指定宽高的Size结构体
          */
-        Size(double width, double height);
+        Size(double width, double height) noexcept;
 
         /**
          * @brief 从SIZE构造Size结构体
          */
-        Size(const SIZE &size);
+        Size(const SIZE &size) noexcept;
 
         /**
          * @brief 隐式转换SIZE
          */
-        operator SIZE() const;
+        operator SIZE() const noexcept;
 
         /**
          * @brief 判断两个Size是否相等
          */
-        bool Equals(const Size &other) const;
+        bool Equals(const Size &other) const noexcept;
 
         /**
          * @brief 获取描述当前对象的字符串

--- a/sw/inc/Thickness.h
+++ b/sw/inc/Thickness.h
@@ -55,13 +55,16 @@ namespace sw
 
         /**
          * @brief 从RECT结构体构造Thickness结构体
+         * @note 此处RECT被解读为四个独立的边距值（left/top/right/bottom），
+         *       而非角坐标矩形；这与Rect(const RECT&)按角坐标计算width/height
+         *       的语义不同，故标记为explicit以避免误用
          */
-        Thickness(const RECT &rect) noexcept;
+        explicit Thickness(const RECT &rect) noexcept;
 
         /**
-         * @brief 隐式转换为RECT
+         * @brief 显式转换为RECT（与explicit Thickness(const RECT&)对称）
          */
-        operator RECT() const noexcept;
+        explicit operator RECT() const noexcept;
 
         /**
          * @brief 判断两个Thickness是否相同

--- a/sw/inc/Thickness.h
+++ b/sw/inc/Thickness.h
@@ -41,32 +41,32 @@ namespace sw
         /**
          * @brief 构造一个四边都相同的Thickness结构体
          */
-        Thickness(double thickness);
+        Thickness(double thickness) noexcept;
 
         /**
          * @brief 指定横向和纵向值构造Thickness结构体
          */
-        Thickness(double horizontal, double vertical);
+        Thickness(double horizontal, double vertical) noexcept;
 
         /**
          * @brief 指定四边的值构造Thickness结构体
          */
-        Thickness(double left, double top, double right, double bottom);
+        Thickness(double left, double top, double right, double bottom) noexcept;
 
         /**
          * @brief 从RECT结构体构造Thickness结构体
          */
-        Thickness(const RECT &rect);
+        Thickness(const RECT &rect) noexcept;
 
         /**
          * @brief 隐式转换为RECT
          */
-        operator RECT() const;
+        operator RECT() const noexcept;
 
         /**
          * @brief 判断两个Thickness是否相同
          */
-        bool Equals(const Thickness &other) const;
+        bool Equals(const Thickness &other) const noexcept;
 
         /**
          * @brief 获取描述当前对象的字符串

--- a/sw/inc/TreeView.h
+++ b/sw/inc/TreeView.h
@@ -68,7 +68,7 @@ namespace sw
         /**
          * @brief 判断当前项是否有效
          */
-        operator bool() const;
+        explicit operator bool() const;
 
         /**
          * @brief 获取当前项的文本

--- a/sw/inc/UIElement.h
+++ b/sw/inc/UIElement.h
@@ -601,19 +601,19 @@ namespace sw
         virtual UIElement *ToUIElement() override final;
 
         /**
-         * @brief 获取父元素
+         * @brief 获取逻辑树中的父元素
          * @return 父元素指针，如果没有父元素则返回nullptr
          */
         virtual UIElement *GetParent() const override final;
 
         /**
-         * @brief 获取子元素数量
+         * @brief 获取逻辑树中的子元素数量
          * @return 子元素数量
          */
         virtual int GetChildCount() const override final;
 
         /**
-         * @brief 获取指定索引处的子元素
+         * @brief 获取逻辑树中指定索引处的子元素
          * @param index 子元素索引
          * @throw std::out_of_range 如果索引超出范围
          */

--- a/sw/inc/UIElement.h
+++ b/sw/inc/UIElement.h
@@ -7,7 +7,6 @@
 #include "EnumBit.h"
 #include "EventHandlerWrapper.h"
 #include "ILayout.h"
-#include "ITag.h"
 #include "RoutedEvent.h"
 #include "RoutedEventArgs.h"
 #include "Thickness.h"
@@ -64,8 +63,7 @@ namespace sw
      * @brief 表示界面中的元素
      */
     class UIElement : public WndBase,
-                      public ILayout,
-                      public ITag<uint64_t>
+                      public ILayout
     {
     private:
         /**
@@ -135,11 +133,6 @@ namespace sw
          * @brief 记录路由事件的map
          */
         std::unordered_map<RoutedEventType, RoutedEventHandler> _eventMap{};
-
-        /**
-         * @brief 储存用户自定义信息
-         */
-        uint64_t _tag = 0;
 
         /**
          * @brief 布局标记
@@ -276,11 +269,6 @@ namespace sw
          * @brief 是否在不可见时不参与布局
          */
         const Property<bool> CollapseWhenHide;
-
-        /**
-         * @brief 储存用户自定义信息的标记
-         */
-        const Property<uint64_t> Tag;
 
         /**
          * @brief 布局标记，对于不同的布局有不同含义
@@ -618,16 +606,6 @@ namespace sw
          * @throw std::out_of_range 如果索引超出范围
          */
         virtual UIElement &GetChildAt(int index) const override final;
-
-        /**
-         * @brief 获取Tag
-         */
-        virtual uint64_t GetTag() const override;
-
-        /**
-         * @brief 设置Tag
-         */
-        virtual void SetTag(uint64_t tag) override;
 
         /**
          * @brief 获取布局标记

--- a/sw/inc/Variant.h
+++ b/sw/inc/Variant.h
@@ -18,8 +18,19 @@ namespace sw
     };
 
     /**
-     * @brief 通用变体类，用于存储任意类型的对象
-     * @note 持入Variant的类型必须满足C++标准约定：析构函数不抛异常
+     * @brief 通用变体类型容器，类型擦除地持有任意类型对象
+     * @note Variant自身是原生C++值类型，而非DynamicObject派生类。
+     *       它可持有任意类型对象 —— 既包括DynamicObject派生类型，也包括原生C++类型。
+     *       内部按持入类型与语义自动选择存储策略：
+     *       - 值语义 + DynamicObject派生类型：直接以unique_ptr<DynamicObject>持有；
+     *       - 值语义 + 其他原生C++类型：装箱为BoxedObject<T>持有；
+     *       - 引用语义 + DynamicObject派生类型：装箱为BoxedObject<ObjectRef>持有；
+     *       - 引用语义 + 其他原生C++类型：装箱为引用模式的BoxedObject<T>持有；
+     *       这些差异对Object()/IsType/DynamicCast/UnsafeCast等查询接口透明。
+     * @note 默认为值语义（拷贝/赋值会通过克隆函数指针深拷贝内部对象）；
+     *       通过Variant::MakeRef或显式构造ObjectRef可获得引用语义。
+     * @note 持入Variant的类型其析构函数不应抛出异常 —— C++11起析构函数默认即为
+     *       noexcept，Variant的多个noexcept移动操作依赖此前提。
      */
     class Variant final
     {
@@ -45,6 +56,21 @@ namespace sw
          */
         Variant(std::nullptr_t) noexcept
         {
+        }
+
+        /**
+         * @brief 以引用语义构造Variant
+         * @param ref 引用标记
+         * @note 与Variant::MakeRef等价的低层入口，内部以装箱的ObjectRef表示。
+         *       使用方需保证被引用对象在Variant存活期间始终有效。
+         * @note 若ref.ptr为nullptr则构造为空Variant，行为与Variant(std::nullptr_t)一致。
+         */
+        Variant(ObjectRef ref)
+        {
+            if (ref.ptr != nullptr) {
+                _obj.reset(new BoxedObject<ObjectRef>(ref));
+                ResetCloner<ObjectRef>();
+            }
         }
 
         /**
@@ -190,6 +216,23 @@ namespace sw
         void Reset(std::nullptr_t) noexcept
         {
             Reset();
+        }
+
+        /**
+         * @brief 重置Variant对象为指定的引用标记
+         * @param ref 引用标记
+         * @note 内部以装箱的ObjectRef表示，使Variant以引用语义持有DynamicObject。
+         *       使用方需保证被引用对象在Variant存活期间始终有效。
+         * @note 若ref.ptr为nullptr则置为空Variant，行为与Reset(std::nullptr_t)一致。
+         */
+        void Reset(ObjectRef ref)
+        {
+            if (ref.ptr == nullptr) {
+                Reset();
+            } else {
+                _obj.reset(new BoxedObject<ObjectRef>(ref));
+                ResetCloner<ObjectRef>();
+            }
         }
 
         /**

--- a/sw/inc/Variant.h
+++ b/sw/inc/Variant.h
@@ -6,8 +6,9 @@ namespace sw
 {
     /**
      * @brief 通用变体类，用于存储任意类型的对象
+     * @note 持入Variant的类型必须满足C++标准约定：析构函数不抛异常
      */
-    class Variant final : public IEqualityComparable<Variant>
+    class Variant final
     {
     private:
         /**
@@ -27,7 +28,16 @@ namespace sw
         Variant() = default;
 
         /**
+         * @brief 从nullptr构造一个空的Variant对象
+         */
+        Variant(std::nullptr_t) noexcept
+        {
+        }
+
+        /**
          * @brief 通用构造函数，接受任意类型的对象
+         * @warning 若T为基类引用且实际指向派生对象，会发生对象切片；
+         *          如需保留对外部对象的引用语义，请改用BoxedObject<T>::MakeRef显式包装后再放入。
          */
         template <
             typename T,
@@ -39,6 +49,7 @@ namespace sw
 
         /**
          * @brief 拷贝构造函数
+         * @throws std::runtime_error 如果对象不可拷贝
          */
         Variant(const Variant &other)
         {
@@ -58,7 +69,7 @@ namespace sw
         }
 
         /**
-         * @brief 拷贝构造函数
+         * @brief 拷贝赋值运算符
          * @throws std::runtime_error 如果对象不可拷贝
          */
         Variant &operator=(const Variant &other)
@@ -68,7 +79,7 @@ namespace sw
         }
 
         /**
-         * @brief 移动构造函数
+         * @brief 移动赋值运算符
          */
         Variant &operator=(Variant &&other) noexcept
         {
@@ -80,7 +91,7 @@ namespace sw
          * @brief 布尔转换运算符，判断Variant对象是否为空
          * @return 若Variant对象不为空则返回true，否则返回false
          */
-        operator bool() const noexcept
+        explicit operator bool() const noexcept
         {
             return _obj != nullptr;
         }
@@ -95,20 +106,40 @@ namespace sw
         }
 
         /**
-         * @brief 判断两Variant是否为同一对象
+         * @brief 判断Variant对象是否包含值
+         * @return 若Variant对象不为空则返回true，否则返回false
          */
-        bool Equals(const Variant &other) const noexcept
+        bool HasValue() const noexcept
         {
-            return _obj == other._obj;
+            return _obj != nullptr;
+        }
+
+        /**
+         * @brief 判断两Variant是否引用同一对象（指针身份比较）
+         * @return 若两Variant内部持有的对象指针相同（包含都为空）则返回true，否则返回false
+         * @note 这是引用相等而非值相等。若需值相等比较，请通过Object()或DynamicCast<T>()
+         *       获取内部对象后自行比较。
+         */
+        bool ReferenceEquals(const Variant &other) const noexcept
+        {
+            return _obj.get() == other._obj.get();
         }
 
         /**
          * @brief 重置Variant对象为空
          */
-        void Reset()
+        void Reset() noexcept
         {
             _obj.reset();
             _cloner = nullptr;
+        }
+
+        /**
+         * @brief 重置Variant对象为空
+         */
+        void Reset(std::nullptr_t) noexcept
+        {
+            Reset();
         }
 
         /**
@@ -175,9 +206,18 @@ namespace sw
 
         /**
          * @brief 获取内部动态对象指针
-         * @return 内部动态对象指针
+         * @return 内部动态对象指针，若Variant为空则返回nullptr
          */
-        DynamicObject *Object() const noexcept
+        DynamicObject *Object() noexcept
+        {
+            return _obj.get();
+        }
+
+        /**
+         * @brief 获取内部动态对象的常量指针
+         * @return 内部动态对象的常量指针，若Variant为空则返回nullptr
+         */
+        const DynamicObject *Object() const noexcept
         {
             return _obj.get();
         }
@@ -314,6 +354,8 @@ namespace sw
         /**
          * @brief 初始化克隆函数指针
          * @tparam T 对象类型
+         * @note 当T不可拷贝时，克隆函数指针在被调用时抛出std::runtime_error，
+         *       而非在编译期失败 —— 以便不可拷贝类型仍可被存放和移动。
          */
         template <typename T>
         auto ResetCloner()

--- a/sw/inc/Variant.h
+++ b/sw/inc/Variant.h
@@ -338,6 +338,18 @@ namespace sw
         }
 
         /**
+         * @brief 获取内部对象的类型信息
+         * @return 内部对象的类型索引；若Variant为空则返回typeid(void)
+         * @note 语义与DynamicObject::GetType一致 —— 返回内部对象的最派生类型。
+         *       对引用语义的Variant会自动透视到被引用对象。
+         */
+        std::type_index GetType() const
+        {
+            const DynamicObject *p = Object();
+            return p == nullptr ? typeid(void) : p->GetType();
+        }
+
+        /**
          * @brief 判断当前Variant存储的对象是否为指定类型
          * @tparam T 目标类型
          * @param pout 如果不为nullptr，则将转换后的指针赋值给该参数

--- a/sw/inc/Variant.h
+++ b/sw/inc/Variant.h
@@ -5,6 +5,19 @@
 namespace sw
 {
     /**
+     * @brief 动态对象引用标记类型
+     * @note 当Variant内部以BoxedObject<ObjectRef>形式装箱时表示对DynamicObject的引用语义。
+     *       Variant的Object()/IsType/DynamicCast/UnsafeCast会自动透视此标记，
+     *       使引用对象的访问与值语义一致。一般通过Variant::MakeRef构造，无需直接使用。
+     */
+    struct ObjectRef final {
+        /**
+         * @brief 被引用的DynamicObject指针
+         */
+        DynamicObject *ptr;
+    };
+
+    /**
      * @brief 通用变体类，用于存储任意类型的对象
      * @note 持入Variant的类型必须满足C++标准约定：析构函数不抛异常
      */
@@ -35,9 +48,9 @@ namespace sw
         }
 
         /**
-         * @brief 通用构造函数，接受任意类型的对象
+         * @brief 通用构造函数，接受任意类型的对象（值语义）
          * @warning 若T为基类引用且实际指向派生对象，会发生对象切片；
-         *          如需保留对外部对象的引用语义，请改用BoxedObject<T>::MakeRef显式包装后再放入。
+         *          如需保留对外部对象的引用语义，请改用Variant::MakeRef<T>。
          */
         template <
             typename T,
@@ -88,6 +101,42 @@ namespace sw
         }
 
         /**
+         * @brief 创建一个对外部对象的引用Variant（DynamicObject派生类型重载）
+         * @tparam T 被引用的对象类型，必须为DynamicObject的派生类
+         * @param obj 被引用的对象
+         * @return 一个引用语义的Variant，与obj共享生命周期
+         * @note 内部以装箱的ObjectRef表示，Variant的类型查询接口对此透明。
+         *       使用方需保证obj在Variant存活期间始终有效。
+         */
+        template <typename T>
+        static auto MakeRef(T &obj)
+            -> typename std::enable_if<std::is_base_of<DynamicObject, T>::value, Variant>::type
+        {
+            Variant v;
+            v._obj.reset(new BoxedObject<ObjectRef>(ObjectRef{&obj}));
+            v.ResetCloner<ObjectRef>();
+            return v;
+        }
+
+        /**
+         * @brief 创建一个对外部对象的引用Variant（非DynamicObject类型重载）
+         * @tparam T 被引用的对象类型
+         * @param obj 被引用的对象
+         * @return 一个引用语义的Variant，与obj共享生命周期
+         * @note 内部以引用模式的BoxedObject<T>表示。
+         *       使用方需保证obj在Variant存活期间始终有效。
+         */
+        template <typename T>
+        static auto MakeRef(T &obj)
+            -> typename std::enable_if<!std::is_base_of<DynamicObject, T>::value, Variant>::type
+        {
+            Variant v;
+            v._obj.reset(new BoxedObject<T>(BoxedObject<T>::MakeRef(&obj)));
+            v.ResetCloner<T>();
+            return v;
+        }
+
+        /**
          * @brief 布尔转换运算符，判断Variant对象是否为空
          * @return 若Variant对象不为空则返回true，否则返回false
          */
@@ -116,13 +165,14 @@ namespace sw
 
         /**
          * @brief 判断两Variant是否引用同一对象（指针身份比较）
-         * @return 若两Variant内部持有的对象指针相同（包含都为空）则返回true，否则返回false
-         * @note 这是引用相等而非值相等。若需值相等比较，请通过Object()或DynamicCast<T>()
-         *       获取内部对象后自行比较。
+         * @return 若两Variant的有效对象指针相同（含都为空）则返回true，否则返回false
+         * @note 这是引用相等而非值相等。比较的是Object()返回的指针，因此引用语义的
+         *       Variant与持有同一原始对象的Variant会被视为相等。若需值相等比较，
+         *       请通过Object()或DynamicCast<T>()获取内部对象后自行比较。
          */
         bool ReferenceEquals(const Variant &other) const noexcept
         {
-            return _obj.get() == other._obj.get();
+            return Object() == other.Object();
         }
 
         /**
@@ -207,18 +257,40 @@ namespace sw
         /**
          * @brief 获取内部动态对象指针
          * @return 内部动态对象指针，若Variant为空则返回nullptr
+         * @note 若Variant以引用语义持有DynamicObject（即装箱的ObjectRef），
+         *       返回被引用对象的指针；否则返回内部对象指针。
          */
         DynamicObject *Object() noexcept
         {
+            if (_obj == nullptr) {
+                return nullptr;
+            }
+
+            ObjectRef *ref = nullptr;
+
+            if (_obj->IsType<ObjectRef>(&ref)) {
+                return ref->ptr;
+            }
             return _obj.get();
         }
 
         /**
          * @brief 获取内部动态对象的常量指针
          * @return 内部动态对象的常量指针，若Variant为空则返回nullptr
+         * @note 若Variant以引用语义持有DynamicObject（即装箱的ObjectRef），
+         *       返回被引用对象的指针；否则返回内部对象指针。
          */
         const DynamicObject *Object() const noexcept
         {
+            if (_obj == nullptr) {
+                return nullptr;
+            }
+
+            const ObjectRef *ref = nullptr;
+
+            if (_obj->IsType<ObjectRef>(&ref)) {
+                return ref->ptr;
+            }
             return _obj.get();
         }
 
@@ -227,18 +299,20 @@ namespace sw
          * @tparam T 目标类型
          * @param pout 如果不为nullptr，则将转换后的指针赋值给该参数
          * @return 如果Variant对象为指定类型则返回true，否则返回false
+         * @note 对引用语义的Variant会自动透视到被引用对象，调用方无需关心存储形式。
          */
         template <typename T>
         bool IsType(T **pout = nullptr)
         {
-            if (_obj == nullptr) {
+            DynamicObject *p = Object();
+
+            if (p == nullptr) {
                 if (pout != nullptr) {
                     *pout = nullptr;
                 }
                 return false;
-            } else {
-                return _obj->IsType<T>(pout);
             }
+            return p->IsType<T>(pout);
         }
 
         /**
@@ -246,18 +320,20 @@ namespace sw
          * @tparam T 目标类型
          * @param pout 如果不为nullptr，则将转换后的指针赋值给该参数
          * @return 如果Variant对象为指定类型则返回true，否则返回false
+         * @note 对引用语义的Variant会自动透视到被引用对象，调用方无需关心存储形式。
          */
         template <typename T>
         bool IsType(const T **pout = nullptr) const
         {
-            if (_obj == nullptr) {
+            const DynamicObject *p = Object();
+
+            if (p == nullptr) {
                 if (pout != nullptr) {
                     *pout = nullptr;
                 }
                 return false;
-            } else {
-                return _obj->IsType<T>(pout);
             }
+            return p->IsType<T>(pout);
         }
 
         /**
@@ -265,12 +341,17 @@ namespace sw
          * @tparam T 目标类型
          * @return 指定类型的引用
          * @throws std::bad_cast 如果转换失败或Variant为空
+         * @note 对引用语义的Variant会自动透视到被引用对象。
          */
         template <typename T>
         T &DynamicCast()
         {
-            ThrowBadCastIfEmpty();
-            return _obj->DynamicCast<T>();
+            DynamicObject *p = Object();
+
+            if (p == nullptr) {
+                throw std::bad_cast();
+            }
+            return p->DynamicCast<T>();
         }
 
         /**
@@ -278,12 +359,17 @@ namespace sw
          * @tparam T 目标类型
          * @return 指定类型的常量引用
          * @throws std::bad_cast 如果转换失败或Variant为空
+         * @note 对引用语义的Variant会自动透视到被引用对象。
          */
         template <typename T>
         const T &DynamicCast() const
         {
-            ThrowBadCastIfEmpty();
-            return _obj->DynamicCast<T>();
+            const DynamicObject *p = Object();
+
+            if (p == nullptr) {
+                throw std::bad_cast();
+            }
+            return p->DynamicCast<T>();
         }
 
         /**
@@ -292,12 +378,17 @@ namespace sw
          * @return 指定类型的引用
          * @throws std::bad_cast 如果Variant为空
          * @note 若目标类型与存储类型不匹配，则行为未定义
+         * @note 对引用语义的Variant会自动透视到被引用对象。
          */
         template <typename T>
         T &UnsafeCast()
         {
-            ThrowBadCastIfEmpty();
-            return _obj->UnsafeCast<T>();
+            DynamicObject *p = Object();
+
+            if (p == nullptr) {
+                throw std::bad_cast();
+            }
+            return p->UnsafeCast<T>();
         }
 
         /**
@@ -306,25 +397,20 @@ namespace sw
          * @return 指定类型的常量引用
          * @throws std::bad_cast 如果Variant为空
          * @note 若目标类型与存储类型不匹配，则行为未定义
+         * @note 对引用语义的Variant会自动透视到被引用对象。
          */
         template <typename T>
         const T &UnsafeCast() const
         {
-            ThrowBadCastIfEmpty();
-            return _obj->UnsafeCast<T>();
+            const DynamicObject *p = Object();
+
+            if (p == nullptr) {
+                throw std::bad_cast();
+            }
+            return p->UnsafeCast<T>();
         }
 
     private:
-        /**
-         * @brief 抛出Variant为空的异常
-         */
-        void ThrowBadCastIfEmpty() const
-        {
-            if (_obj == nullptr) {
-                throw std::bad_cast();
-            }
-        }
-
         /**
          * @brief 初始化克隆函数指针
          * @tparam T 对象类型

--- a/sw/inc/Variant.h
+++ b/sw/inc/Variant.h
@@ -127,6 +127,20 @@ namespace sw
         }
 
         /**
+         * @brief 创建一个对另一Variant内部对象的引用Variant（Variant转发重载）
+         * @param v 源Variant
+         * @return 一个引用语义的Variant，引用v当前承载的对象；若v为空则返回空Variant
+         * @note 避免对Variant调用泛型MakeRef时产生BoxedObject<Variant>嵌套包装。
+         *       结果直接引用v.Object()返回的指针，因此当v本身已是引用语义时，
+         *       结果与v共享同一被引用对象，不会形成多层引用链。
+         */
+        static Variant MakeRef(Variant &v)
+        {
+            DynamicObject *p = v.Object();
+            return p == nullptr ? Variant{} : MakeRef(*p);
+        }
+
+        /**
          * @brief 创建一个对外部对象的引用Variant（DynamicObject派生类型重载）
          * @tparam T 被引用的对象类型，必须为DynamicObject的派生类
          * @param obj 被引用的对象
@@ -136,7 +150,10 @@ namespace sw
          */
         template <typename T>
         static auto MakeRef(T &obj)
-            -> typename std::enable_if<std::is_base_of<DynamicObject, T>::value, Variant>::type
+            -> typename std::enable_if<
+                !std::is_same<T, Variant>::value &&
+                    std::is_base_of<DynamicObject, T>::value,
+                Variant>::type
         {
             Variant v;
             v._obj.reset(new BoxedObject<ObjectRef>(ObjectRef{&obj}));
@@ -154,7 +171,10 @@ namespace sw
          */
         template <typename T>
         static auto MakeRef(T &obj)
-            -> typename std::enable_if<!std::is_base_of<DynamicObject, T>::value, Variant>::type
+            -> typename std::enable_if<
+                !std::is_same<T, Variant>::value &&
+                    !std::is_base_of<DynamicObject, T>::value,
+                Variant>::type
         {
             Variant v;
             v._obj.reset(new BoxedObject<T>(BoxedObject<T>::MakeRef(&obj)));

--- a/sw/inc/Variant.h
+++ b/sw/inc/Variant.h
@@ -127,62 +127,6 @@ namespace sw
         }
 
         /**
-         * @brief 创建一个对另一Variant内部对象的引用Variant（Variant转发重载）
-         * @param v 源Variant
-         * @return 一个引用语义的Variant，引用v当前承载的对象；若v为空则返回空Variant
-         * @note 避免对Variant调用泛型MakeRef时产生BoxedObject<Variant>嵌套包装。
-         *       结果直接引用v.Object()返回的指针，因此当v本身已是引用语义时，
-         *       结果与v共享同一被引用对象，不会形成多层引用链。
-         */
-        static Variant MakeRef(Variant &v)
-        {
-            DynamicObject *p = v.Object();
-            return p == nullptr ? Variant{} : MakeRef(*p);
-        }
-
-        /**
-         * @brief 创建一个对外部对象的引用Variant（DynamicObject派生类型重载）
-         * @tparam T 被引用的对象类型，必须为DynamicObject的派生类
-         * @param obj 被引用的对象
-         * @return 一个引用语义的Variant，与obj共享生命周期
-         * @note 内部以装箱的ObjectRef表示，Variant的类型查询接口对此透明。
-         *       使用方需保证obj在Variant存活期间始终有效。
-         */
-        template <typename T>
-        static auto MakeRef(T &obj)
-            -> typename std::enable_if<
-                !std::is_same<T, Variant>::value &&
-                    std::is_base_of<DynamicObject, T>::value,
-                Variant>::type
-        {
-            Variant v;
-            v._obj.reset(new BoxedObject<ObjectRef>(ObjectRef{&obj}));
-            v.ResetCloner<ObjectRef>();
-            return v;
-        }
-
-        /**
-         * @brief 创建一个对外部对象的引用Variant（非DynamicObject类型重载）
-         * @tparam T 被引用的对象类型
-         * @param obj 被引用的对象
-         * @return 一个引用语义的Variant，与obj共享生命周期
-         * @note 内部以引用模式的BoxedObject<T>表示。
-         *       使用方需保证obj在Variant存活期间始终有效。
-         */
-        template <typename T>
-        static auto MakeRef(T &obj)
-            -> typename std::enable_if<
-                !std::is_same<T, Variant>::value &&
-                    !std::is_base_of<DynamicObject, T>::value,
-                Variant>::type
-        {
-            Variant v;
-            v._obj.reset(new BoxedObject<T>(BoxedObject<T>::MakeRef(&obj)));
-            v.ResetCloner<T>();
-            return v;
-        }
-
-        /**
          * @brief 布尔转换运算符，判断Variant对象是否为空
          * @return 若Variant对象不为空则返回true，否则返回false
          */
@@ -525,6 +469,107 @@ namespace sw
             _cloner = [](const DynamicObject &other) -> DynamicObject * {
                 throw std::runtime_error("Object is not copy constructible.");
             };
+        }
+
+    public:
+        /**
+         * @brief 就地构造一个值语义的Variant（DynamicObject派生类型重载）
+         * @tparam T 要构造的对象类型，必须为DynamicObject的派生类
+         * @tparam Args 构造参数类型包
+         * @param args 转发给T构造函数的参数
+         * @return 持有就地构造的T对象的Variant
+         * @note 相较于Variant{T{args...}}，避免了一次T的移动构造，
+         *       且支持不可移动/不可拷贝但可构造的类型。
+         */
+        template <typename T, typename... Args>
+        static auto MakeVal(Args &&...args)
+            -> typename std::enable_if<
+                !std::is_same<T, Variant>::value &&
+                    std::is_base_of<DynamicObject, T>::value,
+                Variant>::type
+        {
+            Variant v;
+            v._obj.reset(new T(std::forward<Args>(args)...));
+            v.ResetCloner<T>();
+            return v;
+        }
+
+        /**
+         * @brief 就地构造一个值语义的Variant（非DynamicObject类型重载）
+         * @tparam T 要构造的对象类型
+         * @tparam Args 构造参数类型包
+         * @param args 转发给T构造函数的参数
+         * @return 持有就地装箱构造的T对象的Variant
+         * @note 相较于Variant{T{args...}}，避免了一次T的移动构造，
+         *       且支持不可移动/不可拷贝但可构造的类型。
+         */
+        template <typename T, typename... Args>
+        static auto MakeVal(Args &&...args)
+            -> typename std::enable_if<
+                !std::is_same<T, Variant>::value &&
+                    !std::is_base_of<DynamicObject, T>::value,
+                Variant>::type
+        {
+            Variant v;
+            v._obj.reset(new BoxedObject<T>(std::forward<Args>(args)...));
+            v.ResetCloner<T>();
+            return v;
+        }
+
+        /**
+         * @brief 创建一个对另一Variant内部对象的引用Variant（Variant转发重载）
+         * @param v 源Variant
+         * @return 一个引用语义的Variant，引用v当前承载的对象；若v为空则返回空Variant
+         * @note 避免对Variant调用泛型MakeRef时产生BoxedObject<Variant>嵌套包装。
+         *       结果直接引用v.Object()返回的指针，因此当v本身已是引用语义时，
+         *       结果与v共享同一被引用对象，不会形成多层引用链。
+         */
+        static Variant MakeRef(Variant &v)
+        {
+            DynamicObject *p = v.Object();
+            return p == nullptr ? Variant{} : MakeRef(*p);
+        }
+
+        /**
+         * @brief 创建一个对外部对象的引用Variant（DynamicObject派生类型重载）
+         * @tparam T 被引用的对象类型，必须为DynamicObject的派生类
+         * @param obj 被引用的对象
+         * @return 一个引用语义的Variant，与obj共享生命周期
+         * @note 内部以装箱的ObjectRef表示，Variant的类型查询接口对此透明。
+         *       使用方需保证obj在Variant存活期间始终有效。
+         */
+        template <typename T>
+        static auto MakeRef(T &obj)
+            -> typename std::enable_if<
+                !std::is_same<T, Variant>::value &&
+                    std::is_base_of<DynamicObject, T>::value,
+                Variant>::type
+        {
+            Variant v;
+            v._obj.reset(new BoxedObject<ObjectRef>(ObjectRef{&obj}));
+            v.ResetCloner<ObjectRef>();
+            return v;
+        }
+
+        /**
+         * @brief 创建一个对外部对象的引用Variant（非DynamicObject类型重载）
+         * @tparam T 被引用的对象类型
+         * @param obj 被引用的对象
+         * @return 一个引用语义的Variant，与obj共享生命周期
+         * @note 内部以引用模式的BoxedObject<T>表示。
+         *       使用方需保证obj在Variant存活期间始终有效。
+         */
+        template <typename T>
+        static auto MakeRef(T &obj)
+            -> typename std::enable_if<
+                !std::is_same<T, Variant>::value &&
+                    !std::is_base_of<DynamicObject, T>::value,
+                Variant>::type
+        {
+            Variant v;
+            v._obj.reset(new BoxedObject<T>(BoxedObject<T>::MakeRef(&obj)));
+            v.ResetCloner<T>();
+            return v;
         }
     };
 }

--- a/sw/inc/Variant.h
+++ b/sw/inc/Variant.h
@@ -162,7 +162,16 @@ namespace sw
          */
         bool ReferenceEquals(const Variant &other) const noexcept
         {
-            return Object() == other.Object();
+            const DynamicObject *a = Object();
+            const DynamicObject *b = other.Object();
+
+            if (a == nullptr && b == nullptr) {
+                return true;
+            }
+            if (a == nullptr || b == nullptr) {
+                return false;
+            }
+            return a->ReferenceEquals(*b);
         }
 
         /**

--- a/sw/inc/WndBase.h
+++ b/sw/inc/WndBase.h
@@ -248,21 +248,24 @@ namespace sw
         virtual std::wstring ToString() const;
 
         /**
-         * @brief 获取父元素
-         * @return 父元素指针，如果没有父元素则返回nullptr
+         * @brief 获取逻辑树中的父元素
+         * @return 始终返回nullptr
+         * @note WndBase不管理父子关系；若需访问Win32 HWND父窗口请使用GetParentWnd
          */
         virtual WndBase *GetParent() const override;
 
         /**
-         * @brief 获取子元素数量
-         * @return 子元素数量
+         * @brief 获取逻辑树中的子元素数量
+         * @return 始终返回0
+         * @note WndBase不管理父子关系
          */
         virtual int GetChildCount() const override;
 
         /**
-         * @brief 获取指定索引处的子元素
+         * @brief 获取逻辑树中指定索引处的子元素
          * @param index 子元素索引
-         * @throw std::out_of_range 如果索引超出范围
+         * @throw std::out_of_range 始终抛出
+         * @note WndBase不管理父子关系
          */
         virtual WndBase &GetChildAt(int index) const override;
 
@@ -726,6 +729,13 @@ namespace sw
         virtual bool OnDropFiles(HDROP hDrop);
 
     public:
+        /**
+         * @brief 获取当前窗口对应的Win32父窗口（HWND父）的WndBase包装
+         * @return 若Win32父窗口存在且已注册为WndBase则返回该指针，否则返回nullptr
+         * @note 该函数访问的是Win32 HWND树，而非逻辑树；与GetParent()语义不同
+         */
+        WndBase *GetParentWnd() const;
+
         /**
          * @brief 同步窗口位置和尺寸到内部记录的Rect
          */

--- a/sw/inc/WndBase.h
+++ b/sw/inc/WndBase.h
@@ -734,7 +734,7 @@ namespace sw
          * @return 若Win32父窗口存在且已注册为WndBase则返回该指针，否则返回nullptr
          * @note 该函数访问的是Win32 HWND树，而非逻辑树；与GetParent()语义不同
          */
-        WndBase *GetParentWnd() const;
+        WndBase *GetParentWnd() const noexcept;
 
         /**
          * @brief 同步窗口位置和尺寸到内部记录的Rect
@@ -769,7 +769,7 @@ namespace sw
         /**
          * @brief 获取字体句柄
          */
-        HFONT GetFontHandle();
+        HFONT GetFontHandle() const noexcept;
 
         /**
          * @brief 重画
@@ -781,87 +781,87 @@ namespace sw
         /**
          * @brief 判断当前对象在界面中是否可视，与Visible属性不同的是该函数返回值会受父窗口的影响
          */
-        bool IsVisible() const;
+        bool IsVisible() const noexcept;
 
         /**
          * @brief 获取窗口样式
          */
-        DWORD GetStyle() const;
+        DWORD GetStyle() const noexcept;
 
         /**
          * @brief 设置窗口样式
          */
-        void SetStyle(DWORD style);
+        void SetStyle(DWORD style) noexcept;
 
         /**
          * @brief 判断窗口是否设有指定样式
          * @param mask 样式的位掩码，可以是多个样式
          */
-        bool GetStyle(DWORD mask) const;
+        bool GetStyle(DWORD mask) const noexcept;
 
         /**
          * @brief 打开或关闭指定的样式
          * @param mask 样式的位掩码，可以是多个样式
          * @param value 是否启用指定的样式
          */
-        void SetStyle(DWORD mask, bool value);
+        void SetStyle(DWORD mask, bool value) noexcept;
 
         /**
          * @brief 获取扩展窗口样式
          */
-        DWORD GetExtendedStyle() const;
+        DWORD GetExtendedStyle() const noexcept;
 
         /**
          * @brief 设置扩展窗口样式
          */
-        void SetExtendedStyle(DWORD style);
+        void SetExtendedStyle(DWORD style) noexcept;
 
         /**
          * @brief 判断窗口是否设有指定扩展样式
          * @param mask 扩展样式的位掩码，可以是多个扩展样式
          */
-        bool GetExtendedStyle(DWORD mask);
+        bool GetExtendedStyle(DWORD mask) const noexcept;
 
         /**
          * @brief 打开或关闭指定的扩展样式
          * @param mask 扩展样式的位掩码，可以是多个扩展样式
          * @param value 是否启用指定的扩展样式
          */
-        void SetExtendedStyle(DWORD mask, bool value);
+        void SetExtendedStyle(DWORD mask, bool value) noexcept;
 
         /**
          * @brief 获取用户区点在屏幕上点的位置
          * @param point 用户区坐标
          * @return 该点在屏幕上的坐标
          */
-        Point PointToScreen(const Point &point) const;
+        Point PointToScreen(const Point &point) const noexcept;
 
         /**
          * @brief 获取屏幕上点在当前用户区点的位置
          * @param screenPoint 屏幕上点的坐标
          * @return 该点在用户区的坐标
          */
-        Point PointFromScreen(const Point &screenPoint) const;
+        Point PointFromScreen(const Point &screenPoint) const noexcept;
 
         /**
          * @brief 发送消息（ASCII）
          */
-        LRESULT SendMessageA(UINT uMsg, WPARAM wParam, LPARAM lParam);
+        LRESULT SendMessageA(UINT uMsg, WPARAM wParam, LPARAM lParam) const;
 
         /**
          * @brief 发送消息（UNICODE）
          */
-        LRESULT SendMessageW(UINT uMsg, WPARAM wParam, LPARAM lParam);
+        LRESULT SendMessageW(UINT uMsg, WPARAM wParam, LPARAM lParam) const;
 
         /**
          * @brief 发送消息（ASCII）并立即返回
          */
-        BOOL PostMessageA(UINT uMsg, WPARAM wParam, LPARAM lParam);
+        BOOL PostMessageA(UINT uMsg, WPARAM wParam, LPARAM lParam) const noexcept;
 
         /**
          * @brief 发送消息（UNICODE）并立即返回
          */
-        BOOL PostMessageW(UINT uMsg, WPARAM wParam, LPARAM lParam);
+        BOOL PostMessageW(UINT uMsg, WPARAM wParam, LPARAM lParam) const noexcept;
 
         /**
          * @brief 测试指定点在窗口的哪一部分
@@ -878,23 +878,24 @@ namespace sw
         /**
          * @brief 在窗口线程上执行指定委托，并立即返回
          * @param action 要执行的委托
+         * @return 若成功将委托放入窗口线程的消息队列则返回true，否则返回false
          */
-        void InvokeAsync(const Action<> &action);
+        bool InvokeAsync(const Action<> &action);
 
         /**
          * @brief 获取当前窗口所属线程的线程id
          */
-        DWORD GetThreadId() const;
+        DWORD GetThreadId() const noexcept;
 
         /**
          * @brief 判断当前线程是否为窗口所属线程
          */
-        bool CheckAccess() const;
+        bool CheckAccess() const noexcept;
 
         /**
          * @brief 判断当前对象所属线程是否与另一个WndBase对象所属线程相同
          */
-        bool CheckAccess(const WndBase &other) const;
+        bool CheckAccess(const WndBase &other) const noexcept;
 
     public:
         /**

--- a/sw/src/BmpBox.cpp
+++ b/sw/src/BmpBox.cpp
@@ -88,7 +88,7 @@ bool sw::BmpBox::OnPaint()
     HBITMAP hBitmap    = CreateCompatibleBitmap(hdc, width, height);
     HBITMAP hBitmapOld = (HBITMAP)SelectObject(hdcMem, hBitmap);
 
-    HBRUSH hBackColorBrush = CreateSolidBrush(this->GetRealBackColor());
+    HBRUSH hBackColorBrush = CreateSolidBrush(static_cast<COLORREF>(this->GetRealBackColor()));
     FillRect(hdcMem, &clientRect, hBackColorBrush);
 
     if (this->_hBitmap != NULL &&

--- a/sw/src/ButtonBase.cpp
+++ b/sw/src/ButtonBase.cpp
@@ -37,11 +37,11 @@ sw::ButtonBase::ButtonBase()
               .Getter([](ButtonBase *self) -> Thickness {
                   RECT rect{};
                   self->_GetTextMargin(rect);
-                  return rect;
+                  return Thickness(rect);
               })
               .Setter([](ButtonBase *self, const Thickness &value) {
                   if (self->TextMargin != value) {
-                      RECT rect = value;
+                      RECT rect = static_cast<RECT>(value);
                       self->_SetTextMargin(rect);
                       self->RaisePropertyChanged(&ButtonBase::TextMargin);
                       if (self->_autoSize) {

--- a/sw/src/Color.cpp
+++ b/sw/src/Color.cpp
@@ -1,27 +1,27 @@
 #include "Color.h"
 #include "Utils.h"
 
-sw::Color::Color(uint8_t r, uint8_t g, uint8_t b)
+sw::Color::Color(uint8_t r, uint8_t g, uint8_t b) noexcept
     : r(r), g(g), b(b), _reserved(0)
 {
 }
 
-sw::Color::Color(KnownColors knownColor)
+sw::Color::Color(KnownColors knownColor) noexcept
     : Color(static_cast<COLORREF>(knownColor))
 {
 }
 
-sw::Color::Color(COLORREF color)
+sw::Color::Color(COLORREF color) noexcept
     : r((color >> 0) & 0xFF), g((color >> 8) & 0xFF), b((color >> 16) & 0xFF)
 {
 }
 
-sw::Color::operator COLORREF() const
+sw::Color::operator COLORREF() const noexcept
 {
     return RGB(this->r, this->g, this->b);
 }
 
-bool sw::Color::Equals(const Color &other) const
+bool sw::Color::Equals(const Color &other) const noexcept
 {
     return (this->r == other.r) && (this->g == other.g) && (this->b == other.b);
 }

--- a/sw/src/Color.cpp
+++ b/sw/src/Color.cpp
@@ -12,7 +12,7 @@ sw::Color::Color(KnownColors knownColor) noexcept
 }
 
 sw::Color::Color(COLORREF color) noexcept
-    : r((color >> 0) & 0xFF), g((color >> 8) & 0xFF), b((color >> 16) & 0xFF)
+    : r(GetRValue(color)), g(GetGValue(color)), b(GetBValue(color)), _reserved(0)
 {
 }
 

--- a/sw/src/ColorDialog.cpp
+++ b/sw/src/ColorDialog.cpp
@@ -39,10 +39,10 @@ sw::ColorDialog::ColorDialog()
       SelectedColor(
           Property<Color>::Init(this)
               .Getter([](ColorDialog *self) -> Color {
-                  return self->_cc.rgbResult;
+                  return static_cast<Color>(self->_cc.rgbResult);
               })
               .Setter([](ColorDialog *self, const Color &value) {
-                  self->_cc.rgbResult = value;
+                  self->_cc.rgbResult = static_cast<COLORREF>(value);
               })),
 
       FullOpen(
@@ -69,7 +69,7 @@ sw::ColorDialog::ColorDialog()
 {
     _cc.lStructSize  = sizeof(CHOOSECOLORW);
     _cc.Flags        = DWORD(ColorDialogFlags::RgbInit);
-    _cc.rgbResult    = Color(KnownColors::Black);
+    _cc.rgbResult    = static_cast<COLORREF>(Color(KnownColors::Black));
     _cc.lpCustColors = _defaultCustomColors;
 }
 

--- a/sw/src/FontDialog.cpp
+++ b/sw/src/FontDialog.cpp
@@ -63,10 +63,10 @@ sw::FontDialog::FontDialog()
       SelectedColor(
           Property<Color>::Init(this)
               .Getter([](FontDialog *self) -> Color {
-                  return self->_cf.rgbColors;
+                  return static_cast<Color>(self->_cf.rgbColors);
               })
               .Setter([](FontDialog *self, const Color &value) {
-                  self->_cf.rgbColors = value;
+                  self->_cf.rgbColors = static_cast<COLORREF>(value);
               }))
 {
     _font           = Font::GetDefaultFont();

--- a/sw/src/FrameworkElement.cpp
+++ b/sw/src/FrameworkElement.cpp
@@ -8,6 +8,11 @@ sw::FrameworkElement::FrameworkElement()
                   return self->_dataContextChanged;
               })),
 
+      Tag(
+          Property<Variant>::Init(this)
+              .Getter<&FrameworkElement::GetTag>()
+              .Setter<&FrameworkElement::SetTag>()),
+
       DataContext(
           Property<Variant>::Init(this)
               .Getter([](FrameworkElement *self) -> Variant {
@@ -79,6 +84,19 @@ bool sw::FrameworkElement::RemoveBinding(FieldId propertyId)
     } else {
         this->_bindings.erase(propertyId);
         return true;
+    }
+}
+
+sw::Variant sw::FrameworkElement::GetTag() const
+{
+    return this->_tag;
+}
+
+void sw::FrameworkElement::SetTag(const Variant &tag)
+{
+    if (!this->_tag.ReferenceEquals(tag)) {
+        this->_tag = tag;
+        this->RaisePropertyChanged(&FrameworkElement::Tag);
     }
 }
 

--- a/sw/src/FrameworkElement.cpp
+++ b/sw/src/FrameworkElement.cpp
@@ -9,16 +9,16 @@ sw::FrameworkElement::FrameworkElement()
               })),
 
       DataContext(
-          Property<DynamicObject *>::Init(this)
-              .Getter([](FrameworkElement *self) -> DynamicObject * {
+          Property<Variant>::Init(this)
+              .Getter([](FrameworkElement *self) -> Variant {
                   return self->_dataContext;
               })
-              .Setter([](FrameworkElement *self, DynamicObject *value) {
-                  if (self->_dataContext != value) {
+              .Setter([](FrameworkElement *self, const Variant &value) {
+                  if (!self->_dataContext.ReferenceEquals(value)) {
                       auto oldDataContext = self->CurrentDataContext.Get();
                       self->_dataContext  = value;
                       self->RaisePropertyChanged(&FrameworkElement::DataContext);
-                      if (oldDataContext != value) {
+                      if (oldDataContext != self->_dataContext.Object()) {
                           self->OnCurrentDataContextChanged(oldDataContext);
                       }
                   }
@@ -30,7 +30,7 @@ sw::FrameworkElement::FrameworkElement()
                   DynamicObject *result     = nullptr;
                   FrameworkElement *element = self;
                   do {
-                      result  = element->_dataContext;
+                      result  = element->_dataContext.Object();
                       element = element->GetParent();
                   } while (result == nullptr && element != nullptr);
                   return result;
@@ -87,7 +87,8 @@ void sw::FrameworkElement::OnCurrentDataContextChanged(DynamicObject *oldDataCon
     std::vector<FrameworkElement *> stack;
     stack.push_back(this);
 
-    while (!stack.empty()) {
+    while (!stack.empty()) //
+    {
         auto current = stack.back();
         stack.pop_back();
 
@@ -102,9 +103,11 @@ void sw::FrameworkElement::OnCurrentDataContextChanged(DynamicObject *oldDataCon
 
         int childCount = current->GetChildCount();
 
-        for (int i = 0; i < childCount; i++) {
+        for (int i = 0; i < childCount; ++i) //
+        {
             auto &child = current->GetChildAt(i);
-            if (child._dataContext == nullptr) {
+
+            if (child._dataContext.IsNull()) {
                 stack.push_back(&child);
             }
         }

--- a/sw/src/GroupBox.cpp
+++ b/sw/src/GroupBox.cpp
@@ -43,9 +43,9 @@ void sw::GroupBox::OnDrawBorder(HDC hdc, RECT &rect)
         rect.top + headerHeight};
 
     if (hdc != NULL) {
-        HBRUSH hBrush = CreateSolidBrush(GetRealBackColor());
-        ::SetBkColor(hdc, GetRealBackColor());
-        ::SetTextColor(hdc, GetRealTextColor());
+        HBRUSH hBrush = CreateSolidBrush(static_cast<COLORREF>(GetRealBackColor()));
+        ::SetBkColor(hdc, static_cast<COLORREF>(GetRealBackColor()));
+        ::SetTextColor(hdc, static_cast<COLORREF>(GetRealTextColor()));
         ::SelectObject(hdc, GetFontHandle());
 
         RECT rtHeaderRow = {

--- a/sw/src/Panel.cpp
+++ b/sw/src/Panel.cpp
@@ -105,7 +105,7 @@ bool sw::Panel::OnPaint()
     HWND hwnd = Handle;
     HDC hdc   = BeginPaint(hwnd, &ps);
 
-    HBRUSH hBrush = CreateSolidBrush(GetRealBackColor());
+    HBRUSH hBrush = CreateSolidBrush(static_cast<COLORREF>(GetRealBackColor()));
     FillRect(hdc, &ps.rcPaint, hBrush);
 
     DeleteObject(hBrush);
@@ -177,7 +177,7 @@ void sw::Panel::OnDrawPadding(HDC hdc, RECT &rect)
         HRGN hRgnDiff  = CreateRectRgn(0, 0, 0, 0);
         CombineRgn(hRgnDiff, hRgnOuter, hRgnInner, RGN_DIFF);
 
-        HBRUSH hBrush = CreateSolidBrush(GetRealBackColor());
+        HBRUSH hBrush = CreateSolidBrush(static_cast<COLORREF>(GetRealBackColor()));
         FillRgn(hdc, hRgnDiff, hBrush);
 
         DeleteObject(hRgnOuter);

--- a/sw/src/Point.cpp
+++ b/sw/src/Point.cpp
@@ -2,22 +2,22 @@
 #include "Dip.h"
 #include "Utils.h"
 
-sw::Point::Point(double x, double y)
+sw::Point::Point(double x, double y) noexcept
     : x(x), y(y)
 {
 }
 
-sw::Point::Point(const POINT &point)
+sw::Point::Point(const POINT &point) noexcept
     : x(Dip::PxToDipX(point.x)), y(Dip::PxToDipY(point.y))
 {
 }
 
-sw::Point::operator POINT() const
+sw::Point::operator POINT() const noexcept
 {
     return {Dip::DipToPxX(this->x), Dip::DipToPxY(this->y)};
 }
 
-bool sw::Point::Equals(const Point &other) const
+bool sw::Point::Equals(const Point &other) const noexcept
 {
     return (this->x == other.x) && (this->y == other.y);
 }

--- a/sw/src/Rect.cpp
+++ b/sw/src/Rect.cpp
@@ -2,12 +2,12 @@
 #include "Dip.h"
 #include "Utils.h"
 
-sw::Rect::Rect(double left, double top, double width, double height)
+sw::Rect::Rect(double left, double top, double width, double height) noexcept
     : left(left), top(top), width(width), height(height)
 {
 }
 
-sw::Rect::Rect(const RECT &rect)
+sw::Rect::Rect(const RECT &rect) noexcept
     : left(Dip::PxToDipX(rect.left)),
       top(Dip::PxToDipY(rect.top)),
       width(Dip::PxToDipX(rect.right - rect.left)),
@@ -15,7 +15,7 @@ sw::Rect::Rect(const RECT &rect)
 {
 }
 
-sw::Rect::operator RECT() const
+sw::Rect::operator RECT() const noexcept
 {
     return {Dip::DipToPxX(this->left),
             Dip::DipToPxY(this->top),
@@ -23,17 +23,17 @@ sw::Rect::operator RECT() const
             Dip::DipToPxY(this->top + this->height)};
 }
 
-sw::Point sw::Rect::GetPos() const
+sw::Point sw::Rect::GetPos() const noexcept
 {
     return Point(this->left, this->top);
 }
 
-sw::Size sw::Rect::GetSize() const
+sw::Size sw::Rect::GetSize() const noexcept
 {
     return Size(this->width, this->height);
 }
 
-bool sw::Rect::Equals(const Rect &other) const
+bool sw::Rect::Equals(const Rect &other) const noexcept
 {
     return (this->left == other.left) &&
            (this->top == other.top) &&

--- a/sw/src/Size.cpp
+++ b/sw/src/Size.cpp
@@ -2,22 +2,22 @@
 #include "Dip.h"
 #include "Utils.h"
 
-sw::Size::Size(double width, double height)
+sw::Size::Size(double width, double height) noexcept
     : width(width), height(height)
 {
 }
 
-sw::Size::Size(const SIZE &size)
+sw::Size::Size(const SIZE &size) noexcept
     : width(Dip::PxToDipX(size.cx)), height(Dip::PxToDipY(size.cy))
 {
 }
 
-sw::Size::operator SIZE() const
+sw::Size::operator SIZE() const noexcept
 {
     return {Dip::DipToPxX(this->width), Dip::DipToPxY(this->height)};
 }
 
-bool sw::Size::Equals(const Size &other) const
+bool sw::Size::Equals(const Size &other) const noexcept
 {
     return (this->width == other.width) && (this->height == other.height);
 }

--- a/sw/src/Splitter.cpp
+++ b/sw/src/Splitter.cpp
@@ -67,7 +67,7 @@ bool sw::Splitter::OnPaint()
     RECT rect;
     GetClientRect(hwnd, &rect);
 
-    HBRUSH hBrush = CreateSolidBrush(GetRealBackColor());
+    HBRUSH hBrush = CreateSolidBrush(static_cast<COLORREF>(GetRealBackColor()));
     FillRect(hdc, &rect, hBrush);
 
     if (_drawSplitterLine) {

--- a/sw/src/Thickness.cpp
+++ b/sw/src/Thickness.cpp
@@ -2,22 +2,22 @@
 #include "Dip.h"
 #include "Utils.h"
 
-sw::Thickness::Thickness(double thickness)
+sw::Thickness::Thickness(double thickness) noexcept
     : left(thickness), top(thickness), right(thickness), bottom(thickness)
 {
 }
 
-sw::Thickness::Thickness(double horizontal, double vertical)
+sw::Thickness::Thickness(double horizontal, double vertical) noexcept
     : left(horizontal), top(vertical), right(horizontal), bottom(vertical)
 {
 }
 
-sw::Thickness::Thickness(double left, double top, double right, double bottom)
+sw::Thickness::Thickness(double left, double top, double right, double bottom) noexcept
     : left(left), top(top), right(right), bottom(bottom)
 {
 }
 
-sw::Thickness::Thickness(const RECT &rect)
+sw::Thickness::Thickness(const RECT &rect) noexcept
     : Thickness(
           Dip::PxToDipX(rect.left),
           Dip::PxToDipY(rect.top),
@@ -26,7 +26,7 @@ sw::Thickness::Thickness(const RECT &rect)
 {
 }
 
-sw::Thickness::operator RECT() const
+sw::Thickness::operator RECT() const noexcept
 {
     return RECT{
         Dip::DipToPxX(this->left),
@@ -35,7 +35,7 @@ sw::Thickness::operator RECT() const
         Dip::DipToPxY(this->bottom)};
 }
 
-bool sw::Thickness::Equals(const Thickness &other) const
+bool sw::Thickness::Equals(const Thickness &other) const noexcept
 {
     return (this->left == other.left) &&
            (this->top == other.top) &&

--- a/sw/src/UIElement.cpp
+++ b/sw/src/UIElement.cpp
@@ -1477,8 +1477,8 @@ void sw::UIElement::OnMenuCommand(int id)
 
 bool sw::UIElement::OnColor(HDC hdc, HBRUSH &hRetBrush)
 {
-    COLORREF textColor = this->GetRealTextColor();
-    COLORREF backColor = this->GetRealBackColor();
+    COLORREF textColor = static_cast<COLORREF>(this->GetRealTextColor());
+    COLORREF backColor = static_cast<COLORREF>(this->GetRealBackColor());
 
     ::SetTextColor(hdc, textColor);
     ::SetBkColor(hdc, backColor);

--- a/sw/src/UIElement.cpp
+++ b/sw/src/UIElement.cpp
@@ -18,7 +18,6 @@ namespace
     const sw::FieldId _PropId_VerticalAlignment   = sw::Reflection::GetFieldId(&sw::UIElement::VerticalAlignment);
     const sw::FieldId _PropId_ChildCount          = sw::Reflection::GetFieldId(&sw::UIElement::ChildCount);
     const sw::FieldId _PropId_CollapseWhenHide    = sw::Reflection::GetFieldId(&sw::UIElement::CollapseWhenHide);
-    const sw::FieldId _PropId_Tag                 = sw::Reflection::GetFieldId(&sw::UIElement::Tag);
     const sw::FieldId _PropId_LayoutTag           = sw::Reflection::GetFieldId(&sw::UIElement::LayoutTag);
     const sw::FieldId _PropId_ContextMenu         = sw::Reflection::GetFieldId(&sw::UIElement::ContextMenu);
     const sw::FieldId _PropId_Float               = sw::Reflection::GetFieldId(&sw::UIElement::Float);
@@ -91,15 +90,6 @@ sw::UIElement::UIElement()
                           self->_parent->InvalidateMeasure();
                       }
                   }
-              })),
-
-      Tag(
-          Property<uint64_t>::Init(this)
-              .Getter([](UIElement *self) -> uint64_t {
-                  return self->GetTag();
-              })
-              .Setter([](UIElement *self, uint64_t value) {
-                  self->SetTag(value);
               })),
 
       LayoutTag(
@@ -771,19 +761,6 @@ int sw::UIElement::GetChildCount() const
 sw::UIElement &sw::UIElement::GetChildAt(int index) const
 {
     return *this->_children.at(index);
-}
-
-uint64_t sw::UIElement::GetTag() const
-{
-    return this->_tag;
-}
-
-void sw::UIElement::SetTag(uint64_t tag)
-{
-    if (this->_tag != tag) {
-        this->_tag = tag;
-        this->RaisePropertyChanged(_PropId_Tag);
-    }
 }
 
 uint64_t sw::UIElement::GetLayoutTag() const

--- a/sw/src/Window.cpp
+++ b/sw/src/Window.cpp
@@ -357,7 +357,7 @@ bool sw::Window::OnPaint()
     HBITMAP hBmpWnd = CreateCompatibleBitmap(hdc, sizeClient.cx, sizeClient.cy);
     HBITMAP hBmpOld = (HBITMAP)SelectObject(hdcMem, hBmpWnd);
 
-    HBRUSH hBrush = CreateSolidBrush(GetRealBackColor());
+    HBRUSH hBrush = CreateSolidBrush(static_cast<COLORREF>(GetRealBackColor()));
     FillRect(hdcMem, &rtClient, hBrush);
     BitBlt(hdc, 0, 0, sizeClient.cx, sizeClient.cy, hdcMem, 0, 0, SRCCOPY);
 

--- a/sw/src/WndBase.cpp
+++ b/sw/src/WndBase.cpp
@@ -335,8 +335,7 @@ std::wstring sw::WndBase::ToString() const
 
 sw::WndBase *sw::WndBase::GetParent() const
 {
-    HWND hwnd = ::GetParent(this->_hwnd);
-    return WndBase::GetWndBase(hwnd);
+    return nullptr;
 }
 
 int sw::WndBase::GetChildCount() const
@@ -1151,6 +1150,12 @@ bool sw::WndBase::OnMeasureItemSelf(MEASUREITEMSTRUCT *pMeasure)
 bool sw::WndBase::OnDropFiles(HDROP hDrop)
 {
     return false;
+}
+
+sw::WndBase *sw::WndBase::GetParentWnd() const
+{
+    HWND hwnd = ::GetParent(this->_hwnd);
+    return WndBase::GetWndBase(hwnd);
 }
 
 void sw::WndBase::UpdateInternalRect()

--- a/sw/src/WndBase.cpp
+++ b/sw/src/WndBase.cpp
@@ -1152,10 +1152,10 @@ bool sw::WndBase::OnDropFiles(HDROP hDrop)
     return false;
 }
 
-sw::WndBase *sw::WndBase::GetParentWnd() const
+sw::WndBase *sw::WndBase::GetParentWnd() const noexcept
 {
     HWND hwnd = ::GetParent(this->_hwnd);
-    return WndBase::GetWndBase(hwnd);
+    return hwnd == NULL ? nullptr : WndBase::GetWndBase(hwnd);
 }
 
 void sw::WndBase::UpdateInternalRect()
@@ -1208,7 +1208,7 @@ void sw::WndBase::UpdateFont()
     this->FontChanged(this->_hfont);
 }
 
-HFONT sw::WndBase::GetFontHandle()
+HFONT sw::WndBase::GetFontHandle() const noexcept
 {
     return this->_hfont;
 }
@@ -1219,27 +1219,27 @@ void sw::WndBase::Redraw(bool erase, bool updateWindow)
     if (updateWindow) UpdateWindow(this->_hwnd);
 }
 
-bool sw::WndBase::IsVisible() const
+bool sw::WndBase::IsVisible() const noexcept
 {
     return IsWindowVisible(this->_hwnd);
 }
 
-DWORD sw::WndBase::GetStyle() const
+DWORD sw::WndBase::GetStyle() const noexcept
 {
     return DWORD(GetWindowLongPtrW(this->_hwnd, GWL_STYLE));
 }
 
-void sw::WndBase::SetStyle(DWORD style)
+void sw::WndBase::SetStyle(DWORD style) noexcept
 {
     SetWindowLongPtrW(this->_hwnd, GWL_STYLE, LONG_PTR(style));
 }
 
-bool sw::WndBase::GetStyle(DWORD mask) const
+bool sw::WndBase::GetStyle(DWORD mask) const noexcept
 {
     return (DWORD(GetWindowLongPtrW(this->_hwnd, GWL_STYLE)) & mask) == mask;
 }
 
-void sw::WndBase::SetStyle(DWORD mask, bool value)
+void sw::WndBase::SetStyle(DWORD mask, bool value) noexcept
 {
     DWORD newstyle =
         value ? (DWORD(GetWindowLongPtrW(this->_hwnd, GWL_STYLE)) | mask)
@@ -1247,22 +1247,22 @@ void sw::WndBase::SetStyle(DWORD mask, bool value)
     SetWindowLongPtrW(this->_hwnd, GWL_STYLE, LONG_PTR(newstyle));
 }
 
-DWORD sw::WndBase::GetExtendedStyle() const
+DWORD sw::WndBase::GetExtendedStyle() const noexcept
 {
     return DWORD(GetWindowLongPtrW(this->_hwnd, GWL_EXSTYLE));
 }
 
-void sw::WndBase::SetExtendedStyle(DWORD style)
+void sw::WndBase::SetExtendedStyle(DWORD style) noexcept
 {
     SetWindowLongPtrW(this->_hwnd, GWL_EXSTYLE, LONG_PTR(style));
 }
 
-bool sw::WndBase::GetExtendedStyle(DWORD mask)
+bool sw::WndBase::GetExtendedStyle(DWORD mask) const noexcept
 {
     return (DWORD(GetWindowLongPtrW(this->_hwnd, GWL_EXSTYLE)) & mask) == mask;
 }
 
-void sw::WndBase::SetExtendedStyle(DWORD mask, bool value)
+void sw::WndBase::SetExtendedStyle(DWORD mask, bool value) noexcept
 {
     DWORD newstyle =
         value ? (DWORD(GetWindowLongPtrW(this->_hwnd, GWL_EXSTYLE)) | mask)
@@ -1270,36 +1270,36 @@ void sw::WndBase::SetExtendedStyle(DWORD mask, bool value)
     SetWindowLongPtrW(this->_hwnd, GWL_EXSTYLE, LONG_PTR(newstyle));
 }
 
-sw::Point sw::WndBase::PointToScreen(const Point &point) const
+sw::Point sw::WndBase::PointToScreen(const Point &point) const noexcept
 {
     POINT p = point;
     ClientToScreen(this->_hwnd, &p);
     return p;
 }
 
-sw::Point sw::WndBase::PointFromScreen(const Point &screenPoint) const
+sw::Point sw::WndBase::PointFromScreen(const Point &screenPoint) const noexcept
 {
     POINT p = screenPoint;
     ScreenToClient(this->_hwnd, &p);
     return p;
 }
 
-LRESULT sw::WndBase::SendMessageA(UINT uMsg, WPARAM wParam, LPARAM lParam)
+LRESULT sw::WndBase::SendMessageA(UINT uMsg, WPARAM wParam, LPARAM lParam) const
 {
     return ::SendMessageA(this->_hwnd, uMsg, wParam, lParam);
 }
 
-LRESULT sw::WndBase::SendMessageW(UINT uMsg, WPARAM wParam, LPARAM lParam)
+LRESULT sw::WndBase::SendMessageW(UINT uMsg, WPARAM wParam, LPARAM lParam) const
 {
     return ::SendMessageW(this->_hwnd, uMsg, wParam, lParam);
 }
 
-BOOL sw::WndBase::PostMessageA(UINT uMsg, WPARAM wParam, LPARAM lParam)
+BOOL sw::WndBase::PostMessageA(UINT uMsg, WPARAM wParam, LPARAM lParam) const noexcept
 {
     return ::PostMessageA(this->_hwnd, uMsg, wParam, lParam);
 }
 
-BOOL sw::WndBase::PostMessageW(UINT uMsg, WPARAM wParam, LPARAM lParam)
+BOOL sw::WndBase::PostMessageW(UINT uMsg, WPARAM wParam, LPARAM lParam) const noexcept
 {
     return ::PostMessageW(this->_hwnd, uMsg, wParam, lParam);
 }
@@ -1323,27 +1323,37 @@ void sw::WndBase::Invoke(const Action<> &action)
     }
 }
 
-void sw::WndBase::InvokeAsync(const Action<> &action)
+bool sw::WndBase::InvokeAsync(const Action<> &action)
 {
-    if (action == nullptr)
-        return;
-    else {
-        Action<> *p = new Action<>(action);
-        this->PostMessageW(WM_InvokeAction, true, reinterpret_cast<LPARAM>(p));
+    bool result;
+
+    if (action == nullptr) {
+        result = false;
+    } else {
+        auto *p = new Action<>(action);
+
+        if (this->PostMessageW(
+                WM_InvokeAction, true, reinterpret_cast<LPARAM>(p)) != FALSE) {
+            result = true;
+        } else {
+            delete p;
+            result = false;
+        }
     }
+    return result;
 }
 
-DWORD sw::WndBase::GetThreadId() const
+DWORD sw::WndBase::GetThreadId() const noexcept
 {
     return GetWindowThreadProcessId(this->_hwnd, NULL);
 }
 
-bool sw::WndBase::CheckAccess() const
+bool sw::WndBase::CheckAccess() const noexcept
 {
     return this->GetThreadId() == GetCurrentThreadId();
 }
 
-bool sw::WndBase::CheckAccess(const WndBase &other) const
+bool sw::WndBase::CheckAccess(const WndBase &other) const noexcept
 {
     return this == &other || this->GetThreadId() == other.GetThreadId();
 }


### PR DESCRIPTION
This pull request introduces several important improvements to the framework's core property, delegate, and data context systems, with a focus on enhanced safety, flexibility, and documentation. The main changes include a refactor of the `DataContext` and `Tag` mechanisms to use the `Variant` type for improved type safety and reference semantics, significant enhancements to the exception and move/copy safety of the delegate system, and improved documentation and macro comments for property definition.

### Data Context and Tag Refactor

* The `FrameworkElement` class now uses `Variant` for both `DataContext` and `Tag`, replacing raw pointers and enabling reference semantics and type safety. `DataContext` should now be set using `Variant::MakeRef` for external objects. The class also implements the `ITag<Variant>` interface and exposes `GetTag`/`SetTag` methods. (`sw/inc/FrameworkElement.h`, `examples/10_datacontext/MyWindow.hpp`) [[1]](diffhunk://#diff-e42bcd5036005a4e0c7884882ea848f9888a6060c0a8947a2a7cd1eccfcfc7c3R4-R6) [[2]](diffhunk://#diff-e42bcd5036005a4e0c7884882ea848f9888a6060c0a8947a2a7cd1eccfcfc7c3L32-R51) [[3]](diffhunk://#diff-e42bcd5036005a4e0c7884882ea848f9888a6060c0a8947a2a7cd1eccfcfc7c3R64-R75) [[4]](diffhunk://#diff-e42bcd5036005a4e0c7884882ea848f9888a6060c0a8947a2a7cd1eccfcfc7c3R142-R152) [[5]](diffhunk://#diff-9af140e45f8c10eab0853bd94212b7ba62ae65d240ac6119bdb7e9dd6eb25bb5L39-R39)

### Delegate System Safety and Semantics

* The delegate system (`Delegate.h`) has been improved for strong exception safety and correct copy/move semantics. This includes:
  - Strong exception safety in `CallableList` assignment and `Add` methods, with detailed comments explaining the guarantees. (`sw/inc/Delegate.h`) [[1]](diffhunk://#diff-a4bda853a504f9ed863fb661805568da8c80439db49de0aabcefff25d722783fR128-R152) [[2]](diffhunk://#diff-a4bda853a504f9ed863fb661805568da8c80439db49de0aabcefff25d722783fR235-R240) [[3]](diffhunk://#diff-a4bda853a504f9ed863fb661805568da8c80439db49de0aabcefff25d722783fR256-R265)
  - Copy/move operations are explicitly deleted for callable wrapper types to prevent accidental shallow copies. (`sw/inc/Delegate.h`) [[1]](diffhunk://#diff-a4bda853a504f9ed863fb661805568da8c80439db49de0aabcefff25d722783fR499-R506) [[2]](diffhunk://#diff-a4bda853a504f9ed863fb661805568da8c80439db49de0aabcefff25d722783fR546-R552) [[3]](diffhunk://#diff-a4bda853a504f9ed863fb661805568da8c80439db49de0aabcefff25d722783fR589-R595)
  - The logic for adding/removing nested delegates is clarified and documented to ensure symmetry and predictable behavior. (`sw/inc/Delegate.h`) [[1]](diffhunk://#diff-a4bda853a504f9ed863fb661805568da8c80439db49de0aabcefff25d722783fR701-L673) [[2]](diffhunk://#diff-a4bda853a504f9ed863fb661805568da8c80439db49de0aabcefff25d722783fR774-L742)
  - Multicast invocation now avoids repeated moves of arguments except for the final call, improving support for move-only types. (`sw/inc/Delegate.h`) [[1]](diffhunk://#diff-a4bda853a504f9ed863fb661805568da8c80439db49de0aabcefff25d722783fR1020-R1021) [[2]](diffhunk://#diff-a4bda853a504f9ed863fb661805568da8c80439db49de0aabcefff25d722783fL994-R1039) [[3]](diffhunk://#diff-a4bda853a504f9ed863fb661805568da8c80439db49de0aabcefff25d722783fR1068-R1069) [[4]](diffhunk://#diff-a4bda853a504f9ed863fb661805568da8c80439db49de0aabcefff25d722783fL1036-R1081)
  - The conversion operator to `bool` for delegates is now explicit. (`sw/inc/Delegate.h`)

### Color Class API Improvements

* The `Color` class constructors and conversion operators are now `noexcept`, and conversions between `COLORREF` and `Color` are explicit to avoid accidental implicit conversions. (`sw/inc/Color.h`)

### Property Definition Macros and Documentation

* The property definition macros in `Macros.h` have improved comments and documentation, clarifying their usage and behavior for both field-based and expression-based properties. (`sw/inc/Macros.h`) [[1]](diffhunk://#diff-690ad993c73a3b9b0025c41e30ff101b97978cf71c6ee5fc960d1c0ae00c0e43L9-R22) [[2]](diffhunk://#diff-690ad993c73a3b9b0025c41e30ff101b97978cf71c6ee5fc960d1c0ae00c0e43L31-R34) [[3]](diffhunk://#diff-690ad993c73a3b9b0025c41e30ff101b97978cf71c6ee5fc960d1c0ae00c0e43L50-R59)

### Single Header File Generation

* The single-header build script now generates richer file-level documentation and pragma guards for both the header and implementation files, clarifying their auto-generated nature. (`single_header/build.py`) [[1]](diffhunk://#diff-2ce532ecc37df90b565ee10fcd413d5274f06b2d08fa99497849d43605747ecaL18-R33) [[2]](diffhunk://#diff-2ce532ecc37df90b565ee10fcd413d5274f06b2d08fa99497849d43605747ecaL118-R147)

These changes collectively improve the robustness, clarity, and usability of the framework, especially around data binding, delegate/event handling, and API documentation.